### PR TITLE
fix: handle null data response in from_be_dict for BE prices

### DIFF
--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -3148,10 +3148,20 @@ class MarketPrices:
         if not data:
             return cls(PriceData(), PriceData())
 
+        # data.get("data") can return None when the BE API has not yet
+        # published tomorrow's prices (typically before ~14:00 CET).
+        data_inner = data.get("data")
+        if not data_inner:
+            _LOGGER.debug(
+                "BE market prices: 'data' key is absent or null "
+                "(prices likely not yet published). Returning empty prices."
+            )
+            return cls(PriceData(), PriceData())
+
         try:
-            payload = data.get("data").get("marketPrices", {})
-        except KeyError as err:
-                    raise ValueError(f"Invalid response format: %s" % err) from err
+            payload = data_inner.get("marketPrices", {})
+        except (KeyError, AttributeError) as err:
+            raise ValueError(f"Invalid response format: %s" % err) from err
 
         # electricity_data = data.get("electricityPrices", {})
         # gas_data = data.get("gasPrices", {})


### PR DESCRIPTION
## Problem

\`MarketPrices.from_be_dict()\` crashes with \`AttributeError: 'NoneType' object has no attribute 'get'\` every day before approximately 14:00 CET.

The Frank Energie BE API returns \`{"data": null}\` when tomorrow's prices have not yet been published. The current code calls \`.get()\` on the result of \`data.get("data")\` without checking for \`None\` first:

\`\`\`python
payload = data.get("data").get("marketPrices", {})  # crashes when data["data"] is None
\`\`\`

The \`except KeyError\` block does not catch \`AttributeError\`, so the exception propagates to the HA coordinator and causes repeated ERROR log entries.

## Fix

- Add an explicit null guard after \`data.get("data")\`. Return empty \`PriceData\` gracefully with a debug log message when the API has no prices yet.
- Extend the except clause to catch \`AttributeError\` as a safety net.

## Impact

- Eliminates daily coordinator crash before ~14:00 CET for Belgian Frank Energie users
- No behaviour change when prices are available
- Downstream HA automations (Predbat, EVCC) are no longer disrupted by this error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness of market price data handling to gracefully process incomplete or missing information without errors.
  * Improved error handling to catch additional failure conditions during data retrieval and processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->