### PR TITLE
fix(MonthSummary): soft-return None on absent/empty payload

### DIFF
--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -513,14 +513,17 @@ class FrankEnergie:
         response = await self._query(query)
         return EnergyConsumption.from_dict(response)
 
-    async def month_summary(self, site_reference: str) -> MonthSummary:
+    async def month_summary(self, site_reference: str) -> MonthSummary | None:
         """Retrieve the month summary for the specified month.
 
         Args:
             month: The month for which to retrieve the summary. Defaults to the current month.
 
         Returns:
-            The month summary information.
+            The month summary information, or ``None`` when Frank Energie has
+            no summary to deliver yet (typical for the first few days of a
+            new billing month, before the previous month's invoice is
+            generated).
 
         Raises:
             AuthRequiredException: If the client is not authenticated.

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -1882,6 +1882,9 @@ class MonthSummary:
         if not payload:
             return None
 
+        if not isinstance(payload, dict):
+            raise RequestException("Unexpected monthSummary payload type")
+
         expected_costs = payload.get("expectedCosts")
         last_reading = payload.get("lastMeterReadingDate")
         actual_costs = payload.get("actualCostsUntilLastMeterReadingDate")

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -1854,10 +1854,19 @@ class MonthSummary:
 
     @staticmethod
     def from_dict(data: Mapping[str, object]) -> MonthSummary | None:
-        """Parse the response from the monthSummary query."""
+        """Parse the response from the monthSummary query.
+
+        Returns ``None`` when Frank Energie has no summary to deliver yet
+        (absent payload, empty payload, ``data.monthSummary: null``). This is
+        a normal transient state — typically the first few days of a new
+        billing month, before the previous month's invoice is generated.
+
+        Only raises when the FE response is *malformed-but-present*: schema
+        drift, mixed-type fields on a populated summary, etc.
+        """
         _LOGGER.debug("MonthSummary model %s", data)
 
-        if data is None:
+        if not data:
             return None
 
         if errors := data.get("errors"):
@@ -1868,14 +1877,21 @@ class MonthSummary:
         if not isinstance(root, dict):
             raise RequestException("Unexpected response format")
 
-        payload = root.get("monthSummary", {})
+        payload = root.get("monthSummary")
 
-        if payload is None:
-            raise RequestException("Unexpected response")
+        if not payload:
+            return None
 
         expected_costs = payload.get("expectedCosts")
         last_reading = payload.get("lastMeterReadingDate")
         actual_costs = payload.get("actualCostsUntilLastMeterReadingDate")
+
+        if (
+            expected_costs is None
+            and last_reading is None
+            and actual_costs is None
+        ):
+            return None
 
         if not isinstance(expected_costs, (int, float, type(None))):
             raise RequestException("Invalid expectedCosts")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -155,6 +155,18 @@ def test_month_summary_malformed_populated_payload_still_raises():
     assert "Invalid expectedCosts" in str(excinfo.value)
 
 
+@pytest.mark.parametrize(
+    "bad_payload",
+    ["not-a-dict", ["list", "instead"], 42],
+    ids=["string", "list", "int"],
+)
+def test_month_summary_non_dict_payload_raises(bad_payload):
+    """A truthy non-dict monthSummary value is schema drift -> raise."""
+    with pytest.raises(RequestException) as excinfo:
+        MonthSummary.from_dict({"data": {"monthSummary": bad_payload}})
+    assert "Unexpected monthSummary payload type" in str(excinfo.value)
+
+
 #
 # Tests for MarketPrices Model.
 #

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,17 +99,36 @@ def test_month_summary_with_expected_parameters(snapshot: SnapshotAssertion):
 
 
 def test_month_summary_with_missing_parameters():
-    """Test MonthSummary.from_dict with missing parameters."""
-    with pytest.raises(RequestException) as excinfo:
-        MonthSummary.from_dict({})
+    """Empty payload (no summary yet) should resolve to ``None`` rather than raise.
 
-    assert "Unexpected response" in str(excinfo.value)
+    Frank Energie does not publish the previous month's invoice for the first
+    few days of a new billing month; the coordinator must tolerate that gap.
+    """
+    assert MonthSummary.from_dict({}) is None
 
 
-def test_month_summary_with_unexpected_response():
-    """Test MonthSummary.from_dict with unexpected response."""
-    with pytest.raises(RequestException):
-        MonthSummary.from_dict({"data": {"monthSummary": None}})
+def test_month_summary_with_none_payload():
+    """``data.monthSummary: null`` is a normal transient state -> ``None``."""
+    assert MonthSummary.from_dict({"data": {"monthSummary": None}}) is None
+
+
+def test_month_summary_with_empty_payload():
+    """``data.monthSummary: {}`` is a normal transient state -> ``None``."""
+    assert MonthSummary.from_dict({"data": {"monthSummary": {}}}) is None
+
+
+def test_month_summary_with_all_null_fields():
+    """All summary fields null -> ``None`` (defense-in-depth)."""
+    payload = {
+        "data": {
+            "monthSummary": {
+                "expectedCosts": None,
+                "lastMeterReadingDate": None,
+                "actualCostsUntilLastMeterReadingDate": None,
+            }
+        }
+    }
+    assert MonthSummary.from_dict(payload) is None
 
 
 def test_month_summary_error_message():
@@ -118,6 +137,22 @@ def test_month_summary_error_message():
         MonthSummary.from_dict({"errors": [{"message": "help me"}]})
 
     assert "help me" in str(excinfo.value)
+
+
+def test_month_summary_malformed_populated_payload_still_raises():
+    """A populated-but-malformed summary must still raise (schema-drift signal)."""
+    payload = {
+        "data": {
+            "monthSummary": {
+                "expectedCosts": "not-a-number",
+                "lastMeterReadingDate": "2026-05-31",
+                "actualCostsUntilLastMeterReadingDate": 12.34,
+            }
+        }
+    }
+    with pytest.raises(RequestException) as excinfo:
+        MonthSummary.from_dict(payload)
+    assert "Invalid expectedCosts" in str(excinfo.value)
 
 
 #


### PR DESCRIPTION
## Summary

`MonthSummary.from_dict` currently raises `RequestException("Invalid actualCostsUntilLastMeterReadingDate")` (or the sibling `expectedCosts` / `lastMeterReadingDate` variants) whenever Frank Energie temporarily has no monthSummary for the configured site — typically the first few days of a new billing month, before the previous month's invoice is generated.

That hard-raise is the root cause of HiDiHo01/home-assistant-frank_energie#144 (and the structural sibling of #77, #86, #87, #113 — each closed in isolation as new fields were added to the validator chain).

This PR generalizes the fix: **`from_dict` returns `None` on absent / empty / all-null payloads**, and only raises when FE actually returns a populated-but-malformed summary (genuine schema drift).

## Behaviour matrix

| input | before | after |
|---|---|---|
| `from_dict(None)` | `None` | `None` |
| `from_dict({})` | `raise "Invalid actualCosts..."` | `None` |
| `data.monthSummary: null` | `raise "Unexpected response"` | `None` |
| `data.monthSummary: {}` | `raise "Invalid actualCosts..."` | `None` |
| all-fields-null populated payload | `raise "Invalid actualCosts..."` | `None` (defense-in-depth) |
| `errors:[...]` | `raise errors[0].message` | `raise errors[0].message` (unchanged) |
| populated, `expectedCosts: "not-a-number"` | `raise "Invalid expectedCosts"` | `raise "Invalid expectedCosts"` (unchanged) |
| valid payload | parsed MonthSummary | parsed MonthSummary (unchanged) |

## Why this is structural

[home-assistant-frank_energie#144](https://github.com/HiDiHo01/home-assistant-frank_energie/issues/144) shows that the integration coordinator catches the GraphQL error and then calls `MonthSummary.from_dict({})` as a "safe fallback" — but the validator chain re-raises on the empty dict, the exception propagates out of `_async_update_data`, the config entry sticks in `setup_retry`, and **all** entities (including pure-price sensors that don't depend on monthSummary) go `unavailable`.

Patching each new field as it surfaces (#113 -> #144 -> next?) doesn't generalize. Soft-returning `None` for absent payloads while keeping strict validation for populated ones does.

## Tests

`tests/test_models.py` updated:

- `test_month_summary_with_missing_parameters` — `{}` now resolves to `None` (was: expected raise)
- `test_month_summary_with_none_payload` — new, `data.monthSummary: null` -> `None`
- `test_month_summary_with_empty_payload` — new, `data.monthSummary: {}` -> `None`
- `test_month_summary_with_all_null_fields` — new, defense-in-depth
- `test_month_summary_error_message` — unchanged, still raises
- `test_month_summary_malformed_populated_payload_still_raises` — new, schema-drift detection preserved

Local run:

```
$ pytest tests/test_models.py -k "month_summary and not expected_parameters"
6 passed, 18 deselected in 0.29s
```

(`test_month_summary_with_expected_parameters` fails on a stale syrupy snapshot vs. the current `MonthSummary` dataclass shape — pre-existing on `main`, unrelated to this PR. Happy to refresh the snapshot in a follow-up if you'd like.)

## Risk

Behaviour change is strictly "raise -> None" for transient/empty shapes. Every existing caller (`frank_energie.py:559` -> `month_summary()`, `coordinator._fetch_month_summary` in the integration) already handles `None`. No callers depended on the raise for control flow that I could find.

Closes the structural family of monthSummary setup-blocking issues (#77 / #86 / #87 / #113 lineage).

Refs HiDiHo01/home-assistant-frank_energie#144

## Summary by Sourcery

Maak het parsen van `MonthSummary` minder strikt zodat afwezige of lege `monthSummary`-payloads worden beschouwd als een normale, tijdelijke toestand die `None` teruggeeft in plaats van een uitzondering op te werpen, terwijl strikte validatie behouden blijft voor onjuist gevulde responses.

Bug Fixes:
- Voorkom dat parse-fouten van `monthSummary` doorwerken wanneer Frank Energie tijdelijk `monthSummary`-data weglaat of een lege `monthSummary` terugstuurt, zodat coördinatoren met het ontbreken van data op een nette manier kunnen omgaan.

Tests:
- Breid de tests van het `MonthSummary`-model uit om `None`-/lege-/volledig-lege payloads te dekken en om te garanderen dat incorrecte maar wél gevulde payloads nog steeds validatiefouten veroorzaken.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax MonthSummary parsing to treat absent or empty monthSummary payloads as a normal transient state that returns None instead of raising, while preserving strict validation for malformed populated responses.

Bug Fixes:
- Prevent monthSummary parsing errors from propagating when Frank Energie temporarily omits or returns empty monthSummary data, allowing coordinators to handle the absence gracefully.

Tests:
- Extend MonthSummary model tests to cover None/empty/all-null payloads and ensure malformed-but-populated payloads still raise validation errors.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness for incomplete month summary data. The application now gracefully handles missing or empty month summaries as a temporary state rather than treating them as errors, ensuring smoother operation when monthly cost data is not yet available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->