### PR TITLE
fix(auth): skip Authorization header on token renewal mutation

### DIFF
--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -178,7 +178,7 @@ class FrankEnergie:
             "skip-graphcdn": "1",
         }
 
-        if self._auth and self._auth.authToken:
+        if self._auth and self._auth.authToken and query.operation_name != "RenewToken":
             headers["Authorization"] = f"Bearer {self._auth.authToken}"
 
         if extra_headers:

--- a/tests/test_frank_energie.py
+++ b/tests/test_frank_energie.py
@@ -127,6 +127,29 @@ async def test_renew_token(aresponses):
 
 
 @pytest.mark.asyncio
+async def test_renew_token_no_auth_header(aresponses):
+    """Test that renew_token does not send the Authorization header."""
+    async def response_handler(request):
+        assert "Authorization" not in request.headers
+        return aresponses.Response(
+            text=load_fixtures("authentication.json"),
+            status=200,
+            headers={"Content-Type": "application/json"},
+        )
+
+    aresponses.add(SIMPLE_DATA_URL, "/", "POST", response_handler)
+
+    async with aiohttp.ClientSession() as session:
+        api = FrankEnergie(session, "a", "b")  # noqa: S106
+        auth = await api.renew_token()
+        await api.close()
+
+    assert api.is_authenticated is True
+    assert auth.authToken == "hello"
+    assert auth.refreshToken == "world"
+
+
+@pytest.mark.asyncio
 async def test_renew_token_invalid_credentials(aresponses):
     """Test login with invalid credentials."""
     aresponses.add(

--- a/tests/test_frank_energie.py
+++ b/tests/test_frank_energie.py
@@ -127,8 +127,11 @@ async def test_renew_token(aresponses):
 
 
 @pytest.mark.asyncio
+@pytest.mark.allow_socket
 async def test_renew_token_no_auth_header(aresponses):
     """Test that renew_token does not send the Authorization header."""
+    from python_frank_energie.authentication import Authentication
+
     async def response_handler(request):
         assert "Authorization" not in request.headers
         return aresponses.Response(
@@ -141,6 +144,7 @@ async def test_renew_token_no_auth_header(aresponses):
 
     async with aiohttp.ClientSession() as session:
         api = FrankEnergie(session, "a", "b")  # noqa: S106
+        api._auth = Authentication(authToken="expired_token", refreshToken="refresh_token")
         auth = await api.renew_token()
         await api.close()
 


### PR DESCRIPTION
### Summary
Some API gateways/CDNs reject token renewal requests if they carry an expired OAuth token in the Authorization header. Since token renewal mutations do not require authentication, omitting this header allows the request to reach the GraphQL backend.

### Key Changes
- Skip appending the Authorization header inside `_query` when the operation name is `RenewToken`.
- Added `test_renew_token_no_auth_header` unit test.

### Why this is needed
Ensures that expired access tokens do not prevent users from successfully renewing their session via the refresh token, preventing manual re-authentication requirements.

## Summary by Sourcery

Sla het verzenden van de Authorization-header over voor token-vernieuwings-GraphQL-operaties om vernieuwing met verlopen access tokens mogelijk te maken.

Bugfixes:
- Voorkom dat token-vernieuwingsverzoeken een verlopen access token in de Authorization-header opnemen bij het aanroepen van de `RenewToken`-operatie.

Tests:
- Voeg een regressietest toe die ervoor zorgt dat `renew_token`-verzoeken zonder Authorization-header worden verzonden, terwijl daarna nog steeds succesvol geauthenticeerd kan worden.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Skip sending Authorization header for token renewal GraphQL operations to allow renewal with expired access tokens.

Bug Fixes:
- Prevent token renewal requests from including an expired access token in the Authorization header when calling the RenewToken operation.

Tests:
- Add regression test ensuring renew_token requests are sent without an Authorization header while still authenticating successfully afterward.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authorization header handling during token renewal to ensure token refresh requests work properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->