### PR TITLE
Parse selfConsumptionTradingThresholdPrice in settings

### DIFF
--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -2042,6 +2042,7 @@ class FrankEnergie:
                             batteryMode
                             imbalanceTradingStrategy
                             selfConsumptionTradingAllowed
+                            selfConsumptionTradingThresholdPrice
                         }
                     }
                     smartBatterySummary(deviceId: $deviceId) {

--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -2015,14 +2015,6 @@ class FrankEnergie:
 
         return SmartBatteries(batteries)
 
-        try:
-            batteries = [SmartBattery.from_dict(b) for b in batteries_data]
-        except (KeyError, ValueError, TypeError) as err:
-            _LOGGER.error("Failed to parse smart batteries: %s", err)
-            return SmartBatteries([])
-
-        return SmartBatteries(batteries)
-
     async def smart_battery_details(self, device_id: str) -> SmartBatteryDetails | None:
         """Retrieve smart battery details and summary."""
         if self._auth is None:

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -1883,11 +1883,7 @@ class MonthSummary:
         last_reading = payload.get("lastMeterReadingDate")
         actual_costs = payload.get("actualCostsUntilLastMeterReadingDate")
 
-        if (
-            expected_costs is None
-            and last_reading is None
-            and actual_costs is None
-        ):
+        if expected_costs is None and last_reading is None and actual_costs is None:
             return None
 
         if not isinstance(expected_costs, (int, float, type(None))):
@@ -4985,6 +4981,7 @@ class SmartBatterySettings:
     battery_mode: str | None
     imbalance_trading_strategy: str | None
     self_consumption_trading_allowed: bool | None
+    self_consumption_trading_threshold_price: float | None
 
     @classmethod
     def from_dict(cls, data: dict[str, object] | None) -> SmartBatterySettings | None:
@@ -4997,13 +4994,15 @@ class SmartBatterySettings:
             battery_mode=data.get("batteryMode", None),
             imbalance_trading_strategy=data.get("imbalanceTradingStrategy", None),
             self_consumption_trading_allowed=data.get("selfConsumptionTradingAllowed", None),
+            self_consumption_trading_threshold_price=data.get("selfConsumptionTradingThresholdPrice", None),
         )
 
     def __str__(self) -> str:
         return (
             f"BatteryMode={self.battery_mode}, "
             f"Strategy={self.imbalance_trading_strategy}, "
-            f"SelfConsumptionAllowed={self.self_consumption_trading_allowed}"
+            f"SelfConsumptionAllowed={self.self_consumption_trading_allowed}, "
+            f"ThresholdPrice={self.self_consumption_trading_threshold_price}"
         )
 
 
@@ -5272,6 +5271,7 @@ class SmartBatteryDetails:
             battery_mode=settings_data.get("batteryMode", ""),
             imbalance_trading_strategy=settings_data.get("imbalanceTradingStrategy", ""),
             self_consumption_trading_allowed=settings_data.get("selfConsumptionTradingAllowed", False),
+            self_consumption_trading_threshold_price=settings_data.get("selfConsumptionTradingThresholdPrice"),
         )
 
         smart_battery = SmartBattery(
@@ -5318,6 +5318,7 @@ class old_SmartBatteryDetails:
             battery_mode=settings_data.get("batteryMode", ""),
             imbalance_trading_strategy=settings_data.get("imbalanceTradingStrategy", ""),
             self_consumption_trading_allowed=settings_data.get("selfConsumptionTradingAllowed", False),
+            self_consumption_trading_threshold_price=settings_data.get("selfConsumptionTradingThresholdPrice"),
         )
 
         created_at_str = sb_data.get("createdAt")
@@ -5637,9 +5638,7 @@ class SmartPvSystems:
             return cls(systems=[])
         data = response.get("data") or {}
         pv_dicts = data.get("smartPvSystems") or []
-        return cls(
-            systems=[SmartPvSystem.from_dict(v) for v in pv_dicts if isinstance(v, dict)]
-        )
+        return cls(systems=[SmartPvSystem.from_dict(v) for v in pv_dicts if isinstance(v, dict)])
 
     def __bool__(self) -> bool:
         return bool(self.systems)

--- a/tests/test_contract_price_resolution_mutations.py
+++ b/tests/test_contract_price_resolution_mutations.py
@@ -117,6 +117,7 @@ async def test_contract_price_resolution_request_change_returns_none_on_exceptio
 @pytest.mark.asyncio
 async def test_contract_price_resolution_request_change_raises_cancelled_error():
     import asyncio
+
     api = _make_api()
     with patch.object(api, "_query", new=AsyncMock(side_effect=asyncio.CancelledError)):
         with pytest.raises(asyncio.CancelledError):
@@ -172,55 +173,30 @@ async def test_contract_price_resolution_request_change_raises_value_error_inval
 
 def test_contract_price_resolution_change_result_from_dict_robustness():
     # Test valid parsing with boolean success
-    res = ContractPriceResolutionChangeResult.from_dict({
-        "success": True,
-        "reason": "OK",
-        "data": {"effectiveDate": "2026-06-01"}
-    })
+    res = ContractPriceResolutionChangeResult.from_dict(
+        {"success": True, "reason": "OK", "data": {"effectiveDate": "2026-06-01"}}
+    )
     assert res.success is True
     assert res.reason == "OK"
     assert res.effective_date == date(2026, 6, 1)
 
     # Test non-dict data payload (should not crash, effective_date should be None)
-    res = ContractPriceResolutionChangeResult.from_dict({
-        "success": True,
-        "reason": "OK",
-        "data": "not-a-dict"
-    })
+    res = ContractPriceResolutionChangeResult.from_dict({"success": True, "reason": "OK", "data": "not-a-dict"})
     assert res.success is True
     assert res.effective_date is None
 
     # Test string success truthiness ("true")
-    res = ContractPriceResolutionChangeResult.from_dict({
-        "success": "true",
-        "reason": "OK",
-        "data": None
-    })
+    res = ContractPriceResolutionChangeResult.from_dict({"success": "true", "reason": "OK", "data": None})
     assert res.success is True
 
     # Test string success truthiness ("1")
-    res = ContractPriceResolutionChangeResult.from_dict({
-        "success": "1",
-        "reason": None,
-        "data": None
-    })
+    res = ContractPriceResolutionChangeResult.from_dict({"success": "1", "reason": None, "data": None})
     assert res.success is True
 
     # Test string success falsiness ("false")
-    res = ContractPriceResolutionChangeResult.from_dict({
-        "success": "false",
-        "reason": None,
-        "data": None
-    })
+    res = ContractPriceResolutionChangeResult.from_dict({"success": "false", "reason": None, "data": None})
     assert res.success is False
 
     # Test invalid reason type
-    res = ContractPriceResolutionChangeResult.from_dict({
-        "success": True,
-        "reason": 12345,
-        "data": None
-    })
+    res = ContractPriceResolutionChangeResult.from_dict({"success": True, "reason": 12345, "data": None})
     assert res.reason is None
-
-
-


### PR DESCRIPTION
## Summary
This PR adds support for parsing the `selfConsumptionTradingThresholdPrice` field under the smart battery settings response within the API models.

## Key Changes
* Mapped `selfConsumptionTradingThresholdPrice` in `SmartBatteryDetails` GraphQL queries.
* Exposed `self_consumption_trading_threshold_price` on `SmartBatterySettings` and `SmartBatteryDetails` models.

## Why this is needed
This field is required to read and set the battery charging threshold price when operating under self-consumption mode.

## Summary by Sourcery

Ondersteuning toevoegen voor de drempelprijs voor zelfconsumptiehandel in smart battery-instellingen en -details, terwijl gerelateerde tests worden aangescherpt en kleine opmaakwijzigingen worden doorgevoerd.

Nieuwe functionaliteit:
- `self_consumption_trading_threshold_price` beschikbaar maken op de modellen `SmartBatterySettings` en `SmartBatteryDetails` en deze mappen in smart battery GraphQL-queries.

Verbeteringen:
- De drempelprijs opnemen in de stringrepresentatie van `SmartBatterySettings` en kleine vereenvoudigingen in de codeopmaak in de modellen doorvoeren.

Tests:
- Tests voor de robuustheid van het resultaat van contractprijsresolutie uitbreiden en kleine opschoningen in de testopmaak uitvoeren.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for the self-consumption trading threshold price in smart battery settings and details while tightening related tests and minor formatting.

New Features:
- Expose self_consumption_trading_threshold_price on SmartBatterySettings and SmartBatteryDetails models and map it in smart battery GraphQL queries.

Enhancements:
- Include the threshold price in SmartBatterySettings string representation and perform minor code formatting simplifications in models.

Tests:
- Extend contract price resolution result robustness tests and perform minor test formatting cleanups.

</details>