### PR TITLE
fix(models): make UserSmartFeedInStatus.from_dict null-safe for users without a feed-in contract

### DIFF
--- a/python_frank_energie/authentication.py
+++ b/python_frank_energie/authentication.py
@@ -124,16 +124,3 @@ class Authentication:
     def __repr__(self) -> str:
         """Hide sensitive token values."""
         return "Authentication(auth_token=***, refresh_token=***)"
-
-
-@dataclass
-class AuthenticationResult:
-    """Class to hold authentication result after login or refresh.
-
-    Attributes:
-        authToken: The current valid auth token.
-        refreshToken: The token used to refresh the auth token.
-    """
-
-    authToken: str
-    refreshToken: str

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -5520,8 +5520,21 @@ class UserSmartFeedInStatus(DictLikeMixin):
     user_id: str
 
     @classmethod
-    def from_dict(cls, data: dict[str, object]) -> UserSmartFeedInStatus:
-        payload = data.get("data", {}).get("userSmartFeedIn") or data
+    def from_dict(cls, data: dict[str, object]) -> UserSmartFeedInStatus | None:
+        """Parse the ``UserSmartFeedIn`` GraphQL response.
+
+        Returns ``None`` when the API reports no feed-in contract for this
+        user (i.e. ``userSmartFeedIn`` is ``null`` in the response).  We do
+        NOT attempt a feature-flag pre-flight check before calling this
+        endpoint because there is no field in the user or connection data that
+        reliably indicates feed-in eligibility.  Returning ``None`` here is
+        the correct sentinel value; the coordinator treats it as "feature not
+        available for this user" without logging an error.
+        """
+        payload = data.get("data", {}).get("userSmartFeedIn")
+        if payload is None:
+            # API returns null for users without a feed-in contract.
+            return None
         return cls(
             has_accepted_terms=payload["hasAcceptedTerms"],
             is_activated=payload["isActivated"],


### PR DESCRIPTION
## Summary

Two fixes in `authentication.py` and `models.py`, raised by HiDiHo01 in PR #140 review.

## Key Changes

### 1. `UserSmartFeedInStatus.from_dict` — null-safe

The previous implementation used an `or data` fallback when the API payload was `null`:

```python
payload = data.get("data", {}).get("userSmartFeedIn") or data
```

When `userSmartFeedIn` is `null` (normal for users without a feed-in contract), `payload` fell back to the raw response dict, which does not contain keys like `hasAcceptedTerms`. The bare key accesses raised `KeyError` — silently swallowed by the coordinator's broad `except` on every refresh cycle for non-feed-in users.

```python
# After
payload = data.get("data", {}).get("userSmartFeedIn")
if payload is None:
    return None  # API returns null for users without a feed-in contract
```

Returning `None` is the correct sentinel — the coordinator already handles `None` returns from all `_fetch_*` methods gracefully.

### Why no feature-flag pre-flight check?

- There is **no field in `User` or `Connection` data** that reliably indicates feed-in eligibility before the first API call.
- The endpoint returns `null` for non-feed-in users — a single cheap GraphQL query resolved cleanly at the model layer.
- The right place to signal "feature not available" is `from_dict`, not a coordinator-level flag with no basis in the data model.

---

### 2. `AuthenticationResult` — removed dead class

`AuthenticationResult` had **zero references** anywhere in either repo:
- Not imported or used in `python-frank-energie` or `home-assistant-frank_energie`
- Not exported from `__init__.py` (only `Authentication` is)
- Duplicates the role of `Authentication`, which uses the canonical snake_case field names (`auth_token` / `refresh_token`) with backward-compat camelCase properties

Raised directly by HiDiHo01: _"only `from .authentication import Authentication` should be used"_.

## Why this is needed

- Non-feed-in users were silently hitting a `KeyError` on every coordinator refresh, masking real API behaviour.
- The dead `AuthenticationResult` class was a maintenance hazard — any future developer could mistakenly use it instead of `Authentication`.