### PR TITLE
Avoid logging errors for features that are not enabled

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python-frank-energie"
-version = "2026.6.18"
+version = "2026.6.19"
 description = "Asynchronous Python client for the Frank Energie"
 authors = ["HiDiHo01"]
 maintainers = ["HiDiHo01"]

--- a/python_frank_energie/__init__.py
+++ b/python_frank_energie/__init__.py
@@ -15,7 +15,7 @@ from .models import (
     PriceData,
 )
 
-__version__ = "2026.3.21"
+__version__ = "2026.6.19"
 
 __all__ = [
     # Core client

--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -823,7 +823,7 @@ class FrankEnergie:
             #     _LOGGER.debug("Unexpected format for 'enodeChargers': %s", chargers)
             #     return []
             return EnodeChargers.from_dict(chargers_data)
-        except (SmartChargingNotEnabledException, SmartTradingNotEnabledException) as error:
+        except SmartChargingNotEnabledException as error:
             _LOGGER.debug("Smart charging not enabled: %s", error)
             return {}
         except Exception as error:
@@ -2487,7 +2487,7 @@ class FrankEnergie:
         try:
             _LOGGER.debug("Querying smart batteries")
             response = await self._query(query)
-        except (SmartChargingNotEnabledException, SmartTradingNotEnabledException) as e:
+        except SmartTradingNotEnabledException as e:
             _LOGGER.debug("Smart trading not enabled: %s", e)
             return SmartBatteries([])
         except Exception as e:
@@ -2880,7 +2880,7 @@ class FrankEnergie:
         try:
             _LOGGER.debug("Querying enode vehicles")
             response = await self._query(query)
-        except (SmartChargingNotEnabledException, SmartTradingNotEnabledException) as e:
+        except SmartChargingNotEnabledException as e:
             _LOGGER.debug("Smart charging not enabled: %s", e)
             return None
         except Exception as e:

--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -58,7 +58,7 @@ _LOGGER = logging.getLogger(__name__)
 if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
-VERSION = "2026.6.18"
+VERSION = "2026.6.19"
 
 
 class FrankEnergieQuery:
@@ -823,6 +823,9 @@ class FrankEnergie:
             #     _LOGGER.debug("Unexpected format for 'enodeChargers': %s", chargers)
             #     return []
             return EnodeChargers.from_dict(chargers_data)
+        except (SmartChargingNotEnabledException, SmartTradingNotEnabledException) as error:
+            _LOGGER.debug("Smart charging not enabled: %s", error)
+            return {}
         except Exception as error:
             _LOGGER.debug("Error in enode_chargers: %s", error)
             _LOGGER.exception("Unexpected error during query: %s", error)
@@ -2484,6 +2487,9 @@ class FrankEnergie:
         try:
             _LOGGER.debug("Querying smart batteries")
             response = await self._query(query)
+        except (SmartChargingNotEnabledException, SmartTradingNotEnabledException) as e:
+            _LOGGER.debug("Smart trading not enabled: %s", e)
+            return SmartBatteries([])
         except Exception as e:
             _LOGGER.error("Failed to query smart batteries: %s", e)
             return SmartBatteries([])
@@ -2874,7 +2880,9 @@ class FrankEnergie:
         try:
             _LOGGER.debug("Querying enode vehicles")
             response = await self._query(query)
-            # return response["data"]["enodeVehicles"]
+        except (SmartChargingNotEnabledException, SmartTradingNotEnabledException) as e:
+            _LOGGER.debug("Smart charging not enabled: %s", e)
+            return None
         except Exception as e:
             _LOGGER.error("Failed to query enode vehicles: %s", e)
             return None


### PR DESCRIPTION
# Summary
This pull request prevents the client library from raising and logging unexpected error tracebacks when a user's account does not have smart charging or smart trading features activated. Instead, it catches these known capability exceptions and logs them at the `DEBUG` level.

# Why this is needed
When a user does not have smart charging or smart trading products enabled on their Frank Energie account, the API returns a `user-error:smart-charging-not-enabled` or `user-error:smart-trading-not-enabled` GraphQL error. The client library was previously catching these as generic exceptions and dumping error logs with traceback details, causing false alarms in client integrations (like Home Assistant).

# Key Changes
- Caught `SmartChargingNotEnabledException` in `enode_chargers` and `enode_vehicles`, returning empty structures (`{}` / `None`) and logging a debug message instead of an error traceback.
- Caught `SmartTradingNotEnabledException` in `smart_batteries`, returning an empty structure (`SmartBatteries([])`) and logging a debug message instead of an error traceback.
- Bumped version to `2026.6.19` in `pyproject.toml` and `python_frank_energie/frank_energie.py`.

Closes https://github.com/HiDiHo01/python-frank-energie/issues/103

## Summary by Sourcery

Afhandelen van uitgeschakelde smart charging- en smart trading-functies zonder fout-tracebacks te loggen en de libraryversie verhogen.

Bugfixes:
- Behandel fouten waarbij smart charging en smart trading niet zijn ingeschakeld als verwachte situaties in enode-opladers, voertuigen en smart batterijen-queries, om overbodige foutlogs te voorkomen.

Verbeteringen:
- Geef lege resultaten terug voor opladers, voertuigen en batterijen wanneer de bijbehorende smart-functies niet zijn ingeschakeld, en log dit alleen op debugniveau in plaats van als fouten.

Build:
- Verhoog de pakketversie naar 2026.6.19.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle disabled smart charging and smart trading features without logging error tracebacks and bump the library version.

Bug Fixes:
- Treat smart charging and smart trading not-enabled errors as expected conditions in enode chargers, vehicles, and smart batteries queries, avoiding noisy error logs.

Enhancements:
- Return empty results for chargers, vehicles, and batteries when the corresponding smart features are not enabled, logging only at debug level instead of as errors.

Build:
- Bump package version to 2026.6.19.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 2026.6.19

* **Bug Fixes**
  * Enhanced error handling when Smart Charging and Smart Trading features are not enabled with improved logging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->