### PR TITLE
Fix null usage and costs totals by preserving None

### DIFF
--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -721,8 +721,8 @@ class UsageItem:
 class EnergyCategory:
     """Representeert een energiecategorie zoals gas, elektriciteit of teruglevering."""
 
-    usage_total: float
-    costs_total: float
+    usage_total: float | None
+    costs_total: float | None
     unit: str
     items: list[UsageItem]
     # costs_this_month: float = 0.0
@@ -737,8 +737,8 @@ class EnergyCategory:
                 # TODO: Check if this is the correct behavior
                 return None
 
-            usage_total = float(data["usageTotal"]) if data.get("usageTotal") is not None else 0.00
-            costs_total = float(data["costsTotal"]) if data.get("costsTotal") is not None else 0.00
+            usage_total = float(data["usageTotal"]) if data.get("usageTotal") is not None else None
+            costs_total = float(data["costsTotal"]) if data.get("costsTotal") is not None else None
 
             return EnergyCategory(
                 usage_total=usage_total,

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -737,8 +737,11 @@ class EnergyCategory:
                 # TODO: Check if this is the correct behavior
                 return None
 
-            usage_total = float(data["usageTotal"]) if data.get("usageTotal") is not None else None
-            costs_total = float(data["costsTotal"]) if data.get("costsTotal") is not None else None
+            usage_val = data.get("usageTotal")
+            usage_total = float(usage_val) if usage_val is not None else None
+
+            costs_val = data.get("costsTotal")
+            costs_total = float(costs_val) if costs_val is not None else None
 
             return EnergyCategory(
                 usage_total=usage_total,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,6 +11,7 @@ from python_frank_energie.models import (
     Authentication,
     ChargeState,
     Connection,
+    EnergyCategory,
     EnodeCharger,
     EnodeChargers,
     Invoices,
@@ -543,3 +544,44 @@ class TestChargeStateNoCarScenario:
         assert state.is_fully_charged is False
         assert state.range == 250
         assert state.is_charging is True
+
+
+class TestEnergyCategory:
+    """Tests for the EnergyCategory model, specifically around null-handling for Issue #79."""
+
+    def test_energy_category_with_valid_usage_and_costs(self):
+        """Test parsing when usageTotal and costsTotal are populated floats."""
+        data = {
+            "usageTotal": 12.34,
+            "costsTotal": 5.67,
+            "unit": "KWH",
+            "items": [],
+        }
+        category = EnergyCategory.from_dict(data)
+        assert category.usage_total == 12.34
+        assert category.costs_total == 5.67
+        assert category.unit == "KWH"
+
+    def test_energy_category_with_none_values(self):
+        """Test parsing when usageTotal and costsTotal are None (Issue #79)."""
+        data = {
+            "usageTotal": None,
+            "costsTotal": None,
+            "unit": "KWH",
+            "items": [],
+        }
+        category = EnergyCategory.from_dict(data)
+        assert category.usage_total is None
+        assert category.costs_total is None
+        assert category.unit == "KWH"
+
+    def test_energy_category_with_missing_keys(self):
+        """Test parsing when usageTotal and costsTotal are missing (Issue #79)."""
+        data = {
+            "unit": "KWH",
+            "items": [],
+        }
+        category = EnergyCategory.from_dict(data)
+        assert category.usage_total is None
+        assert category.costs_total is None
+        assert category.unit == "KWH"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -558,8 +558,8 @@ class TestEnergyCategory:
             "items": [],
         }
         category = EnergyCategory.from_dict(data)
-        assert category.usage_total == 12.34
-        assert category.costs_total == 5.67
+        assert category.usage_total == pytest.approx(12.34)
+        assert category.costs_total == pytest.approx(5.67)
         assert category.unit == "KWH"
 
     def test_energy_category_with_none_values(self):


### PR DESCRIPTION
# Summary
This pull request modifies the `EnergyCategory` model class to preserve `None` values for `usage_total` and `costs_total` instead of defaulting them to `0.00` when the API returns `null`.

# Why this is needed
At the beginning of each day, the Frank Energie API returns `null` for the current day's usage and costs totals until the data is processed. Setting these to `0.00` in the client library causes Home Assistant to record a false `0.00` value in long-term statistics, permanently corrupting the energy dashboard. Preserving `None` enables downstream clients to correctly identify that data is not yet available.

# Key Changes
- Modified `EnergyCategory` dataclass to allow `float | None` for `usage_total` and `costs_total`.
- Modified `EnergyCategory.from_dict` to fallback to `None` instead of `0.00` when `usageTotal` or `costsTotal` is `null` or missing.
- Added comprehensive unit tests in `tests/test_models.py` verifying correct behavior with missing and `null` values.

References HiDiHo01/home-assistant-frank_energie#79

## Dependencies
- [ ] HiDiHo01/python-frank-energie#104
