### PR TITLE
fix: use correct identifier keys for vehicle and charger mutations

### DIFF
--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -995,6 +995,9 @@ class FrankEnergie:
         if "id" not in input_data:
             raise ValueError("input_data must include the charge settings 'id' field.")
 
+        api_input = {**input_data}
+        api_input["vehicleId"] = api_input.pop("id")
+
         query = FrankEnergieQuery(
             """
             mutation EnodeUpdateVehicleChargeSettings($input: EnodeUpdateVehicleChargeSettingsInputType!) {
@@ -1002,7 +1005,7 @@ class FrankEnergie:
             }
             """,
             "EnodeUpdateVehicleChargeSettings",
-            {"input": input_data},
+            {"input": api_input},
         )
 
         try:
@@ -1045,6 +1048,9 @@ class FrankEnergie:
         if "id" not in input_data:
             raise ValueError("input_data must include the charge settings 'id' field.")
 
+        api_input = {**input_data}
+        api_input["chargerId"] = api_input.pop("id")
+
         query = FrankEnergieQuery(
             """
             mutation EnodeUpdateChargerChargeSettings($input: EnodeUpdateChargerChargeSettingsInputType!) {
@@ -1052,7 +1058,7 @@ class FrankEnergie:
             }
             """,
             "EnodeUpdateChargerChargeSettings",
-            {"input": input_data},
+            {"input": api_input},
         )
 
         try:

--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -236,9 +236,7 @@ class FrankEnergie:
         operation_name = query.operation_name
 
         if not operation_name:
-            raise ValueError(
-                "GraphQL operation name must not be empty"
-            )
+            raise ValueError("GraphQL operation name must not be empty")
 
         start = time.monotonic()
 
@@ -980,9 +978,7 @@ class FrankEnergie:
             raise ValueError("input_data must include the charge settings 'id' field.")
 
         if target_key in input_data:
-            raise ValueError(
-                f"Conflicting identifiers: input_data cannot contain both 'id' and '{target_key}'."
-            )
+            raise ValueError(f"Conflicting identifiers: input_data cannot contain both 'id' and '{target_key}'.")
 
         api_input = {**input_data}
         api_input[target_key] = api_input.pop("id")

--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -970,6 +970,24 @@ class FrankEnergie:
 
         return bool(response.get("data", {}).get("smartFeedInDisable", {}).get("success", False))
 
+    def _map_charge_settings_input(self, input_data: dict[str, Any], target_key: str) -> dict[str, Any]:
+        """Validate input_data has 'id' and map it to target_key in a new dictionary.
+
+        Raises:
+            ValueError: If 'id' is missing, or if both 'id' and target_key are present in input_data.
+        """
+        if "id" not in input_data:
+            raise ValueError("input_data must include the charge settings 'id' field.")
+
+        if target_key in input_data:
+            raise ValueError(
+                f"Conflicting identifiers: input_data cannot contain both 'id' and '{target_key}'."
+            )
+
+        api_input = {**input_data}
+        api_input[target_key] = api_input.pop("id")
+        return api_input
+
     async def enode_update_vehicle_charge_settings(self, input_data: dict[str, Any]) -> bool:
         """Update the charge settings for a specific Enode vehicle.
 
@@ -987,16 +1005,12 @@ class FrankEnergie:
 
         Raises:
             AuthRequiredException: If the client is not authenticated.
-            ValueError: If ``input_data`` is missing the required ``id`` field.
+            ValueError: If ``input_data`` is missing the required ``id`` field or both 'id' and 'vehicleId' are present.
         """
         if not self.is_authenticated:
             raise AuthRequiredException("Authentication is required.")
 
-        if "id" not in input_data:
-            raise ValueError("input_data must include the charge settings 'id' field.")
-
-        api_input = {**input_data}
-        api_input["vehicleId"] = api_input.pop("id")
+        api_input = self._map_charge_settings_input(input_data, "vehicleId")
 
         query = FrankEnergieQuery(
             """
@@ -1040,16 +1054,12 @@ class FrankEnergie:
 
         Raises:
             AuthRequiredException: If the client is not authenticated.
-            ValueError: If ``input_data`` is missing the required ``id`` field.
+            ValueError: If ``input_data`` is missing the required ``id`` field or both 'id' and 'chargerId' are present.
         """
         if not self.is_authenticated:
             raise AuthRequiredException("Authentication is required.")
 
-        if "id" not in input_data:
-            raise ValueError("input_data must include the charge settings 'id' field.")
-
-        api_input = {**input_data}
-        api_input["chargerId"] = api_input.pop("id")
+        api_input = self._map_charge_settings_input(input_data, "chargerId")
 
         query = FrankEnergieQuery(
             """

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -2141,7 +2141,7 @@ class MonthSummary:
         if not isinstance(expected_costs, (int, float, type(None))):
             raise RequestException("Invalid expectedCosts")
 
-        if not isinstance(completeness, float):
+        if not isinstance(completeness, (int, float)):
             raise RequestException("Invalid meterReadingDayCompleteness")
 
         if not isinstance(gas_excluded, bool):

--- a/scripts/test_batt_sessions.py
+++ b/scripts/test_batt_sessions.py
@@ -103,7 +103,7 @@ def log_session_data(session: Any) -> None:
 
 
 async def main():
-    """Main function loop."""
+    """Run the main function loop."""
     EMAIL = os.getenv("FRANK_ENERGIE_EMAIL")
     PASSWORD = os.getenv("FRANK_ENERGIE_PASSWORD")
 

--- a/scripts/test_graphql_query_EnodeVehicles.py
+++ b/scripts/test_graphql_query_EnodeVehicles.py
@@ -218,7 +218,7 @@ class FrankEnergie:
             else:
                 raise AuthException("Login response doesn't contain expected data.")
         except (TimeoutError, ClientError) as error:
-            raise AuthException(f"Login failed: {error}")
+            raise AuthException(f"Login failed: {error}") from error
 
     async def test_query(self, site_reference: str, start_date: date) -> dict:
         """Retrieve period usage and costs."""
@@ -235,7 +235,7 @@ class FrankEnergie:
 
 
 async def main():
-    """Main function to authenticate and fetch GraphQL data."""
+    """Run the main function to authenticate and fetch GraphQL data."""
     async with aiohttp.ClientSession() as session:
         client = FrankEnergie(session)
         try:

--- a/scripts/test_me.py
+++ b/scripts/test_me.py
@@ -18,7 +18,7 @@ PASSWORD: str | None = os.getenv("FRANK_ENERGIE_PASSWORD")
 
 async def main() -> None:
     """
-    Main asynchronous function to authenticate and retrieve user info
+    Run the main asynchronous function to authenticate and retrieve user info
     from the Frank Energie API.
     """
     if not EMAIL or not PASSWORD:

--- a/tests/test_smart_controls_mutations.py
+++ b/tests/test_smart_controls_mutations.py
@@ -297,6 +297,13 @@ async def test_enode_update_vehicle_charge_settings_raises_when_id_missing():
 
 
 @pytest.mark.asyncio
+async def test_enode_update_vehicle_charge_settings_raises_when_vehicleId_present():
+    api = _make_api()
+    with pytest.raises(ValueError, match="Conflicting identifiers"):
+        await api.enode_update_vehicle_charge_settings({**VALID_VEHICLE_INPUT, "vehicleId": "another-id"})
+
+
+@pytest.mark.asyncio
 async def test_enode_update_vehicle_charge_settings_returns_false_on_graphql_error():
     api = _make_api()
     mock_response = {"errors": [{"message": "Vehicle not found"}]}
@@ -380,6 +387,13 @@ async def test_enode_update_charger_charge_settings_raises_when_id_missing():
     api = _make_api()
     with pytest.raises(ValueError, match="'id' field"):
         await api.enode_update_charger_charge_settings({"deadline": "2026-05-29T07:00:00Z"})
+
+
+@pytest.mark.asyncio
+async def test_enode_update_charger_charge_settings_raises_when_chargerId_present():
+    api = _make_api()
+    with pytest.raises(ValueError, match="Conflicting identifiers"):
+        await api.enode_update_charger_charge_settings({**VALID_CHARGER_INPUT, "chargerId": "another-id"})
 
 
 @pytest.mark.asyncio

--- a/tests/test_smart_controls_mutations.py
+++ b/tests/test_smart_controls_mutations.py
@@ -327,7 +327,9 @@ async def test_enode_update_vehicle_charge_settings_sends_input_as_variable():
     with patch.object(api, "_query", new=AsyncMock(return_value=mock_response)) as mock_q:
         await api.enode_update_vehicle_charge_settings(VALID_VEHICLE_INPUT)
     called_query = mock_q.call_args[0][0]
-    assert called_query.variables["input"] == VALID_VEHICLE_INPUT
+    expected_input = {**VALID_VEHICLE_INPUT}
+    expected_input["vehicleId"] = expected_input.pop("id")
+    assert called_query.variables["input"] == expected_input
     assert called_query.operation_name == "EnodeUpdateVehicleChargeSettings"
 
 
@@ -404,7 +406,9 @@ async def test_enode_update_charger_charge_settings_sends_correct_operation_name
         await api.enode_update_charger_charge_settings(VALID_CHARGER_INPUT)
     called_query = mock_q.call_args[0][0]
     assert called_query.operation_name == "EnodeUpdateChargerChargeSettings"
-    assert called_query.variables["input"] == VALID_CHARGER_INPUT
+    expected_input = {**VALID_CHARGER_INPUT}
+    expected_input["chargerId"] = expected_input.pop("id")
+    assert called_query.variables["input"] == expected_input
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Fixes the GraphQL schema validation error when updating Enode charge settings for vehicles or chargers.

## Key Changes
- Internal mapping of the identifier field from `"id"` to `"vehicleId"` in `enode_update_vehicle_charge_settings`.
- Internal mapping of the identifier field from `"id"` to `"chargerId"` in `enode_update_charger_charge_settings`.
- Updated unit test assertions in `test_smart_controls_mutations.py`.

## Why this is needed
The Frank Energie GraphQL backend validation fails on `EnodeUpdateVehicleChargeSettingsInputType` and `EnodeUpdateChargerChargeSettingsInputType` when the `"id"` field is passed, since the schema expects the keys to be `"vehicleId"` and `"chargerId"` respectively.

## Samenvatting door Sourcery

Map client charge settings identifiers naar de verwachte keys van het GraphQL-schema en verscherp de validatie rond deze inputs.

Bugfixes:
- Vertaal identifiers voor vehicle charge settings input van `id` naar `vehicleId` voordat de GraphQL-mutation wordt verzonden.
- Vertaal identifiers voor charger charge settings input van `id` naar `chargerId` voordat de GraphQL-mutation wordt verzonden.
- Geef een foutmelding wanneer zowel de generieke `id` als de specifieke identifier-key (`vehicleId`/`chargerId`) worden meegegeven in charge settings input.
- Behandel niet-float numerieke waarden als geldig voor `meterReadingDayCompleteness` in de models parser.
- Behoud de oorspronkelijke login-fout als oorzaak wanneer deze wordt verpakt in een `AuthException`.

Verbeteringen:
- Introduceer een gedeelde helper om charge settings identifiers te valideren en te remappen voor Enode vehicle- en charger-mutations.
- Verduidelijk de docstrings van de main-functie in test-scripts om hun runtime-gedrag beter te beschrijven.

Tests:
- Breid smart controls-mutationtests uit om conflicterende identifier-inputs en het nieuwe identifier-remappinggedrag voor vehicle- en charger charge settings te dekken.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Map client charge settings identifiers to the GraphQL schema’s expected keys and tighten validation around these inputs.

Bug Fixes:
- Translate vehicle charge settings input identifiers from 'id' to 'vehicleId' before sending the GraphQL mutation.
- Translate charger charge settings input identifiers from 'id' to 'chargerId' before sending the GraphQL mutation.
- Raise an error when both the generic 'id' and specific identifier key (vehicleId/chargerId) are provided in charge settings input.
- Treat non-float numeric values as valid for meterReadingDayCompleteness in the models parser.
- Preserve the original login error as the cause when wrapping it in an AuthException.

Enhancements:
- Introduce a shared helper to validate and remap charge settings identifiers for Enode vehicle and charger mutations.
- Clarify main function docstrings in test scripts to better describe their runtime behavior.

Tests:
- Extend smart controls mutation tests to cover conflicting identifier inputs and the new identifier remapping behavior for vehicle and charger charge settings.

</details>

<details>
<summary>Original summary in English</summary>

## Samenvatting door Sourcery

Map client charge settings identifiers naar de verwachte keys van het GraphQL-schema en verscherp de validatie rond deze inputs.

Bugfixes:
- Vertaal identifiers voor vehicle charge settings input van `id` naar `vehicleId` voordat de GraphQL-mutation wordt verzonden.
- Vertaal identifiers voor charger charge settings input van `id` naar `chargerId` voordat de GraphQL-mutation wordt verzonden.
- Geef een foutmelding wanneer zowel de generieke `id` als de specifieke identifier-key (`vehicleId`/`chargerId`) worden meegegeven in charge settings input.
- Behandel niet-float numerieke waarden als geldig voor `meterReadingDayCompleteness` in de models parser.
- Behoud de oorspronkelijke login-fout als oorzaak wanneer deze wordt verpakt in een `AuthException`.

Verbeteringen:
- Introduceer een gedeelde helper om charge settings identifiers te valideren en te remappen voor Enode vehicle- en charger-mutations.
- Verduidelijk de docstrings van de main-functie in test-scripts om hun runtime-gedrag beter te beschrijven.

Tests:
- Breid smart controls-mutationtests uit om conflicterende identifier-inputs en het nieuwe identifier-remappinggedrag voor vehicle- en charger charge settings te dekken.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Map client charge settings identifiers to the GraphQL schema’s expected keys and tighten validation around these inputs.

Bug Fixes:
- Translate vehicle charge settings input identifiers from 'id' to 'vehicleId' before sending the GraphQL mutation.
- Translate charger charge settings input identifiers from 'id' to 'chargerId' before sending the GraphQL mutation.
- Raise an error when both the generic 'id' and specific identifier key (vehicleId/chargerId) are provided in charge settings input.
- Treat non-float numeric values as valid for meterReadingDayCompleteness in the models parser.
- Preserve the original login error as the cause when wrapping it in an AuthException.

Enhancements:
- Introduce a shared helper to validate and remap charge settings identifiers for Enode vehicle and charger mutations.
- Clarify main function docstrings in test scripts to better describe their runtime behavior.

Tests:
- Extend smart controls mutation tests to cover conflicting identifier inputs and the new identifier remapping behavior for vehicle and charger charge settings.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vehicle and charger charge settings mutations to properly format data before sending to the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->