### PR TITLE
fix: PriceData.__add__ should preserve metadata

### DIFF
--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -9,7 +9,7 @@ import logging
 import math
 from collections import defaultdict
 from collections.abc import Iterable, Iterator, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, date, datetime, timedelta
 from enum import StrEnum
 from statistics import mean
@@ -2942,14 +2942,16 @@ class PriceData:
     # ------------------------------------------------------------------ #
     def __add__(self, other: PriceData) -> PriceData:
         """Merge two PriceData objects (preserves metadata of self)."""
-        merged = PriceData(
-            energy_type=self.energy_type,
-            gas_unit=self.gas_unit,
-            elec_unit=self.elec_unit,
-            gas_resolution=self.gas_resolution,
-            elec_resolution=self.elec_resolution,
-            resolution_minutes=self.resolution_minutes,
-        )
+        if self.energy_type and other.energy_type and self.energy_type != other.energy_type:
+            raise ValueError(
+                f"Cannot merge PriceData with different energy types: {self.energy_type} vs {other.energy_type}"
+            )
+        if self.resolution_minutes and other.resolution_minutes and self.resolution_minutes != other.resolution_minutes:
+            raise ValueError(
+                f"Cannot merge PriceData with different resolutions: {self.resolution_minutes} vs {other.resolution_minutes}"
+            )
+
+        merged = replace(self, prices=[])
         merged.price_data = self.price_data + other.price_data
         return merged
 

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field, replace
 from datetime import UTC, date, datetime, timedelta
 from enum import StrEnum
 from statistics import mean
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 from zoneinfo import ZoneInfo
 
 import jwt
@@ -2951,7 +2951,7 @@ class PriceData:
                 f"Cannot merge PriceData with different resolutions: {self.resolution_minutes} vs {other.resolution_minutes}"
             )
 
-        merged = replace(self, prices=[])
+        merged = cast("PriceData", replace(self, prices=[]))
         merged.price_data = self.price_data + other.price_data
         return merged
 

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -2941,8 +2941,15 @@ class PriceData:
     # Dunder helpers                                                       #
     # ------------------------------------------------------------------ #
     def __add__(self, other: PriceData) -> PriceData:
-        """Merge two PriceData objects (preserves energy_type of self)."""
-        merged = PriceData(energy_type=self.energy_type)
+        """Merge two PriceData objects (preserves metadata of self)."""
+        merged = PriceData(
+            energy_type=self.energy_type,
+            gas_unit=self.gas_unit,
+            elec_unit=self.elec_unit,
+            gas_resolution=self.gas_resolution,
+            elec_resolution=self.elec_resolution,
+            resolution_minutes=self.resolution_minutes,
+        )
         merged.price_data = self.price_data + other.price_data
         return merged
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -712,8 +712,6 @@ def test_price_data_add_preserves_metadata() -> None:
         elec_resolution="PT15M",
         resolution_minutes=15,
     )
-    # Add dummy price objects (must be mock or valid dict structure to satisfy post_init? no, price_data is what matters)
-    left.price_data = []
 
     right = PriceData(
         prices=[],
@@ -724,7 +722,6 @@ def test_price_data_add_preserves_metadata() -> None:
         elec_resolution=None,
         resolution_minutes=15,
     )
-    right.price_data = []
 
     # Merge them
     merged = left + right

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -722,7 +722,7 @@ def test_price_data_add_preserves_metadata() -> None:
         elec_unit=None,
         gas_resolution=None,
         elec_resolution=None,
-        resolution_minutes=60,
+        resolution_minutes=15,
     )
     right.price_data = []
 
@@ -736,3 +736,20 @@ def test_price_data_add_preserves_metadata() -> None:
     assert merged.gas_resolution == "PT60M"
     assert merged.elec_resolution == "PT15M"
     assert merged.resolution_minutes == 15
+
+
+def test_price_data_add_validates_metadata() -> None:
+    """Test that PriceData.__add__ validates metadata compatibility."""
+    import pytest
+
+    from python_frank_energie.models import PriceData
+
+    left = PriceData(prices=[], energy_type="electricity", resolution_minutes=15)
+    right_diff_res = PriceData(prices=[], energy_type="electricity", resolution_minutes=60)
+    right_diff_type = PriceData(prices=[], energy_type="gas", resolution_minutes=15)
+
+    with pytest.raises(ValueError, match="Cannot merge PriceData with different resolutions"):
+        _ = left + right_diff_res
+
+    with pytest.raises(ValueError, match="Cannot merge PriceData with different energy types"):
+        _ = left + right_diff_type

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -696,3 +696,43 @@ def test_smart_battery_settings_from_dict_defensive_parsing_unknown_enum_values(
     assert settings.battery_mode is SmartBatteryMode.UNKNOWN
     assert settings.imbalance_trading_strategy is SmartBatteryImbalanceStrategy.UNKNOWN
     assert settings.self_consumption_trading_threshold_price == pytest.approx(0.25)
+
+
+def test_price_data_add_preserves_metadata() -> None:
+    """Test that PriceData.__add__ preserves metadata from the left operand."""
+    from python_frank_energie.models import PriceData
+
+    # Create two PriceData objects with different metadata
+    left = PriceData(
+        prices=[],
+        energy_type="electricity",
+        gas_unit="m3",
+        elec_unit="kWh",
+        gas_resolution="PT60M",
+        elec_resolution="PT15M",
+        resolution_minutes=15,
+    )
+    # Add dummy price objects (must be mock or valid dict structure to satisfy post_init? no, price_data is what matters)
+    left.price_data = []
+
+    right = PriceData(
+        prices=[],
+        energy_type="electricity",
+        gas_unit=None,
+        elec_unit=None,
+        gas_resolution=None,
+        elec_resolution=None,
+        resolution_minutes=60,
+    )
+    right.price_data = []
+
+    # Merge them
+    merged = left + right
+
+    # Assert that the left operand's metadata is preserved
+    assert merged.energy_type == "electricity"
+    assert merged.gas_unit == "m3"
+    assert merged.elec_unit == "kWh"
+    assert merged.gas_resolution == "PT60M"
+    assert merged.elec_resolution == "PT15M"
+    assert merged.resolution_minutes == 15


### PR DESCRIPTION
## Summary
This PR fixes a bug in `PriceData.__add__` where merging two `PriceData` objects dropped crucial metadata, most notably `resolution_minutes`, resetting it to the default of 60.

## Key Changes
- Updated `PriceData.__add__` to preserve all metadata (like `resolution_minutes`, `elec_resolution`, etc.) from the left operand when creating the new merged object.
- Added a unit test to verify that metadata is preserved after using the `+` operator.

## Why this is needed
When the Home Assistant integration (`home-assistant-frank_energie`) merges today's and tomorrow's price data, it uses the `+` operator. For users on 15-minute resolution, dropping the `resolution_minutes` metadata caused the 15-minute price graphs to incorrectly render as 60-minute wide bars as soon as tomorrow's prices became available.

Closes HiDiHo01/home-assistant-frank_energie#221

## Summary by Sourcery

Behoud metadata bij het samenvoegen van `PriceData`-instanties via de `+`-operator om te voorkomen dat configuratie zoals resolutie-instellingen verloren gaat.

Bug Fixes:
- Zorg ervoor dat `PriceData.__add__` alle metadata-velden (zoals resolutie en eenheden) van de linker operand behoudt bij het aanmaken van een samengevoegde instantie.

Tests:
- Voeg een unit test toe die verifieert dat `PriceData.__add__` de metadata van de linker operand behoudt, inclusief resolutie- en eenheidsvelden, na het samenvoegen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve metadata when merging PriceData instances via the + operator to avoid dropping configuration like resolution settings.

Bug Fixes:
- Ensure PriceData.__add__ retains all metadata fields (such as resolution and units) from the left operand when creating a merged instance.

Tests:
- Add a unit test verifying that PriceData.__add__ preserves the left operand's metadata, including resolution and unit fields, after merging.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Merging pricing datasets now preserves the original metadata (energy type, gas/electricity units, pricing resolution, and time resolution).
  * Addition now validates compatibility and rejects mismatched datasets to prevent incorrect combined results.

* **Tests**
  * Added unit tests to confirm metadata preservation when combining pricing data.
  * Added unit tests to ensure incompatible pricing data raises an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->