### PR TITLE
fix: deduplicate prices by date_from on merge

### DIFF
--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -2952,13 +2952,13 @@ class PriceData:
             )
 
         merged = cast("PriceData", replace(self, prices=[]))
-        
-        unique_prices = {}
+
+        unique_prices: dict[datetime, Price] = {}
         for price in self.price_data + other.price_data:
             if price.date_from not in unique_prices:
                 unique_prices[price.date_from] = price
-                
-        merged.price_data = list(unique_prices.values())
+
+        merged.price_data = sorted(unique_prices.values(), key=lambda p: p.date_from)
         return merged
 
     def __str__(self) -> str:

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -2952,7 +2952,13 @@ class PriceData:
             )
 
         merged = cast("PriceData", replace(self, prices=[]))
-        merged.price_data = self.price_data + other.price_data
+        
+        unique_prices = {}
+        for price in self.price_data + other.price_data:
+            if price.date_from not in unique_prices:
+                unique_prices[price.date_from] = price
+                
+        merged.price_data = list(unique_prices.values())
         return merged
 
     def __str__(self) -> str:


### PR DESCRIPTION
## Summary
This PR adds time-based deduplication to `PriceData.__add__`.

## Key Changes
- In `python_frank_energie/models.py`, `PriceData.__add__` now deduplicates combined price entries by their `date_from` attribute. This guarantees that merging price lists with overlapping times (e.g., today's cache + tomorrow's cache) will yield exactly one price entry per hour.

## Why this is needed
When the Home Assistant integration promotes tomorrow's prices into today's cache, any overlapping hours (e.g., historical prices still in the source data) will result in duplicate entries being created. While downstream calculations (like min/max) often still work, the list continuously grows. This deduplication prevents duplicate data bloat and ensures correctness.

## Summary by Sourcery

Bug Fixes:
- Voorkom dubbele prijsvermeldingen bij het samenvoegen van overlappende `PriceData`-instanties door ervoor te zorgen dat er slechts één entry per `date_from`-waarde behouden blijft.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate price entries when merging overlapping PriceData instances by ensuring only one entry per date_from value is kept.

</details>