### PR TITLE
chore: secure workflows and fix clear-text logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,44 +19,43 @@ jobs:
         python-version: ["3.13", "3.14"]
 
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
-      with:
-        egress-policy: block
-        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
-          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
-    - name: Checkout repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+        with:
+          egress-policy: block
+          allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\nsonarcloud.io:443\nobjects.githubusercontent.com:443\n\nuploads.github.com:443\nupload.pypi.org:443\ntest.pypi.org:443\ncodecov.io:443\nuploader.codecov.io:443"
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
 
-    - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: "pip"
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r requirements_test.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements_test.txt
 
-    - name: Lint (ruff)
-      run: |
-        ruff check .
+      - name: Lint (ruff)
+        run: |
+          ruff check .
 
-    - name: Type check (mypy)
-      run: |
-        mypy custom_components
+      - name: Type check (mypy)
+        run: |
+          mypy custom_components
 
-    - name: Run tests with coverage
-      run: |
-        pytest \
-          --cov=custom_components \
-          --cov-report=xml \
-          --cov-report=term-missing
+      - name: Run tests with coverage
+        run: |
+          pytest \
+            --cov=custom_components \
+            --cov-report=xml \
+            --cov-report=term-missing
 
-    - name: Upload coverage artifact
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v7
-      with:
-        name: coverage-${{ matrix.python-version }}
-        path: coverage.xml
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v7
+        with:
+          name: coverage-${{ matrix.python-version }}
+          path: coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,15 @@
 name: CI
 
+permissions:
+  contents: read
 on:
   push:
   pull_request:
 
 jobs:
   test:
+    permissions:
+      contents: read
     name: Python ${{ matrix.python-version }} tests
     runs-on: ubuntu-latest
 
@@ -15,38 +19,44 @@ jobs:
         python-version: ["3.13", "3.14"]
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
+    - name: Harden Runner
+      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+      with:
+        egress-policy: block
+        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
+          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
+    - name: Checkout repository
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: "pip"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements_test.txt
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements_test.txt
 
-      - name: Lint (ruff)
-        run: |
-          ruff check .
+    - name: Lint (ruff)
+      run: |
+        ruff check .
 
-      - name: Type check (mypy)
-        run: |
-          mypy custom_components
+    - name: Type check (mypy)
+      run: |
+        mypy custom_components
 
-      - name: Run tests with coverage
-        run: |
-          pytest \
-            --cov=custom_components \
-            --cov-report=xml \
-            --cov-report=term-missing
+    - name: Run tests with coverage
+      run: |
+        pytest \
+          --cov=custom_components \
+          --cov-report=xml \
+          --cov-report=term-missing
 
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-${{ matrix.python-version }}
-          path: coverage.xml
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v7
+      with:
+        name: coverage-${{ matrix.python-version }}
+        path: coverage.xml

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,4 +1,3 @@
----
 name: Dependabot auto-merge
 on: pull_request
 
@@ -8,18 +7,27 @@ permissions:
 
 jobs:
   dependabot:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v3
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Harden Runner
+      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+      with:
+        egress-policy: block
+        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
+          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
+    - name: Dependabot metadata
+      id: metadata
+      uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # @v3
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Enable auto-merge for Dependabot PRs
+      if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+      run: gh pr merge --auto --squash "$PR_URL"
+      env:
+        PR_URL: ${{github.event.pull_request.html_url}}
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,22 +12,20 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
-      with:
-        egress-policy: block
-        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
-          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
-    - name: Dependabot metadata
-      id: metadata
-      uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # @v3
-      with:
-        github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+        with:
+          egress-policy: block
+          allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\nsonarcloud.io:443\nobjects.githubusercontent.com:443\n\nuploads.github.com:443\nupload.pypi.org:443\ntest.pypi.org:443\ncodecov.io:443\nuploader.codecov.io:443"
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # @v3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-    - name: Enable auto-merge for Dependabot PRs
-      if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
-      run: gh pr merge --auto --squash "$PR_URL"
-      env:
-        PR_URL: ${{github.event.pull_request.html_url}}
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,9 +3,9 @@ name: PR Labeler
 on:
   pull_request_target:
     types:
-      - opened
-      - synchronize
-      - reopened
+    - opened
+    - synchronize
+    - reopened
 
 permissions:
   contents: read
@@ -13,21 +13,29 @@ permissions:
 
 jobs:
   labeler:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:
-      - name: Apply labels
-        uses: actions/labeler@v6
+    - name: Harden Runner
+      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+      with:
+        egress-policy: block
+        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
+          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
+    - name: Apply labels
+      uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # @v6
 
-      - name: Size label
-        uses: codelytv/pr-size-labeler@v1
-        with:
-          xs_label: size/xs
-          xs_max_size: 10
-          s_label: size/s
-          s_max_size: 50
-          m_label: size/m
-          m_max_size: 200
-          l_label: size/l
-          l_max_size: 500
-          xl_label: size/xl
+    - name: Size label
+      uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # @095a41fca88b8764fd9e008ad269bcdb82bb38b9
+      with:
+        xs_label: size/xs
+        xs_max_size: 10
+        s_label: size/s
+        s_max_size: 50
+        m_label: size/m
+        m_max_size: 200
+        l_label: size/l
+        l_max_size: 500
+        xl_label: size/xl

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,9 +3,9 @@ name: PR Labeler
 on:
   pull_request_target:
     types:
-    - opened
-    - synchronize
-    - reopened
+      - opened
+      - synchronize
+      - reopened
 
 permissions:
   contents: read
@@ -18,24 +18,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
-      with:
-        egress-policy: block
-        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
-          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
-    - name: Apply labels
-      uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # @v6
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+        with:
+          egress-policy: block
+          allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\nsonarcloud.io:443\nobjects.githubusercontent.com:443\n\nuploads.github.com:443\nupload.pypi.org:443\ntest.pypi.org:443\ncodecov.io:443\nuploader.codecov.io:443"
+      - name: Apply labels
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # @v6
 
-    - name: Size label
-      uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # @095a41fca88b8764fd9e008ad269bcdb82bb38b9
-      with:
-        xs_label: size/xs
-        xs_max_size: 10
-        s_label: size/s
-        s_max_size: 50
-        m_label: size/m
-        m_max_size: 200
-        l_label: size/l
-        l_max_size: 500
-        xl_label: size/xl
+      - name: Size label
+        uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # @095a41fca88b8764fd9e008ad269bcdb82bb38b9
+        with:
+          xs_label: size/xs
+          xs_max_size: 10
+          s_label: size/s
+          s_max_size: 50
+          m_label: size/m
+          m_max_size: 200
+          l_label: size/l
+          l_max_size: 500
+          xl_label: size/xl

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,9 +1,13 @@
 name: Pre-commit Linting & CI
 
+permissions:
+  contents: read
 on: [pull_request]
 
 jobs:
   precommit:
+    permissions:
+      contents: read
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     strategy:
@@ -11,103 +15,112 @@ jobs:
       matrix:
         python-version: ["3.13", "3.14"]
         include:
-          - id: bandit
-            name: Check with bandit
-          - id: black
-            name: Check code style
-          - id: blacken-docs
-            name: Check code style in documentation
-          - id: check-ast
-            name: Check Python AST
-          - id: check-case-conflict
-            name: Check for case conflicts
-          - id: check-docstring-first
-            name: Check docstring is first
-          - id: check-executables-have-shebangs
-            name: Check that executables have shebangs
-          - id: check-json
-            name: Check JSON files
-          - id: check-merge-conflict
-            name: Check for merge conflicts
-          - id: check-symlinks
-            name: Check for broken symlinks
-          - id: check-toml
-            name: Check TOML files
-          - id: check-yaml
-            name: Check YAML files
-          - id: codespell
-            name: Check code for common misspellings
-          - id: debug-statements
-            name: Debug Statements and imports (Python)
-          - id: detect-private-key
-            name: Detect Private Keys
-          - id: end-of-file-fixer
-            name: Check End of Files
-          - id: fix-byte-order-marker
-            name: Check UTF-8 byte order marker
-          - id: isort
-            name: Check imports are sorted
-          - id: poetry
-            name: Check pyproject file
-          - id: pyupgrade
-            name: Check for upgradable syntax
-          - id: pytest
-            name: Test with pytest
-          - id: ruff
-            name: Lint with ruff
-          - id: trailing-whitespace
-            name: Trim Trailing Whitespace
-          - id: vulture
-            name: Find unused code
+        - id: bandit
+          name: Check with bandit
+        - id: black
+          name: Check code style
+        - id: blacken-docs
+          name: Check code style in documentation
+        - id: check-ast
+          name: Check Python AST
+        - id: check-case-conflict
+          name: Check for case conflicts
+        - id: check-docstring-first
+          name: Check docstring is first
+        - id: check-executables-have-shebangs
+          name: Check that executables have shebangs
+        - id: check-json
+          name: Check JSON files
+        - id: check-merge-conflict
+          name: Check for merge conflicts
+        - id: check-symlinks
+          name: Check for broken symlinks
+        - id: check-toml
+          name: Check TOML files
+        - id: check-yaml
+          name: Check YAML files
+        - id: codespell
+          name: Check code for common misspellings
+        - id: debug-statements
+          name: Debug Statements and imports (Python)
+        - id: detect-private-key
+          name: Detect Private Keys
+        - id: end-of-file-fixer
+          name: Check End of Files
+        - id: fix-byte-order-marker
+          name: Check UTF-8 byte order marker
+        - id: isort
+          name: Check imports are sorted
+        - id: poetry
+          name: Check pyproject file
+        - id: pyupgrade
+          name: Check for upgradable syntax
+        - id: pytest
+          name: Test with pytest
+        - id: ruff
+          name: Lint with ruff
+        - id: trailing-whitespace
+          name: Trim Trailing Whitespace
+        - id: vulture
+          name: Find unused code
 
     steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Harden Runner
+      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+      with:
+        egress-policy: block
+        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
+          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
+    - name: Check out code from GitHub
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0   # v7.0.0
 
-      - name: Set up Python 3.13
-        id: python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5.5.0
-        with:
-          python-version: ${{ matrix.python-version }}
+    - name: Set up Python 3.13
+      id: python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405   # v5.5.0
+      with:
+        python-version: ${{ matrix.python-version }}
 
-      - name: Get pip cache dir
-        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
+    - name: Get pip cache dir
+      run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
 
-      - name: Restore cached Python PIP packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ env.PIP_CACHE_DIR }}
-          key: pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
-          restore-keys: |
-            pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
-            pip-${{ runner.os }}-v1-
+    - name: Restore cached Python PIP packages
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9   # v6.1.0
+      with:
+        path: ${{ env.PIP_CACHE_DIR }}
+        key: pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version 
+          }}-${{ hashFiles('poetry.lock') }}
+        restore-keys: |
+          pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
+          pip-${{ runner.os }}-v1-
 
-      - name: Install workflow dependencies
-        run: |
-          pip install poetry
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project true
+    - name: Install workflow dependencies
+      run: |
+        pip install poetry
+        poetry config virtualenvs.create true
+        poetry config virtualenvs.in-project true
 
-      - name: Restore cached Python virtual environment
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
-          restore-keys: |
-            venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
-            venv-${{ runner.os }}-v1-
+    - name: Restore cached Python virtual environment
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9   # v6.1.0
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version 
+          }}-${{ hashFiles('poetry.lock') }}
+        restore-keys: |
+          venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
+          venv-${{ runner.os }}-v1-
 
-      - name: Install Python dependencies
-        run: poetry install --no-interaction --with=dev
+    - name: Install Python dependencies
+      run: poetry install --no-interaction --with=dev
 
-      - name: Check poetry.lock is up to date
-        run: poetry check --lock
+    - name: Check poetry.lock is up to date
+      run: poetry check --lock
 
-      - name: Run pre-commit migrate-config
-        run: poetry run pre-commit migrate-config
+    - name: Run pre-commit migrate-config
+      run: poetry run pre-commit migrate-config
 
-      - name: Install pre-commit hooks
-        run: poetry run pre-commit install
+    - name: Install pre-commit hooks
+      run: poetry run pre-commit install
 
-      - name: Run ${{ matrix.name }}
-        run: poetry run pre-commit run ${{ matrix.id }} --all-files --hook-stage manual
+    - name: Run ${{ matrix.name }}
+      run: poetry run pre-commit run ${{ matrix.id }} --all-files --hook-stage 
+        manual

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -15,112 +15,108 @@ jobs:
       matrix:
         python-version: ["3.13", "3.14"]
         include:
-        - id: bandit
-          name: Check with bandit
-        - id: black
-          name: Check code style
-        - id: blacken-docs
-          name: Check code style in documentation
-        - id: check-ast
-          name: Check Python AST
-        - id: check-case-conflict
-          name: Check for case conflicts
-        - id: check-docstring-first
-          name: Check docstring is first
-        - id: check-executables-have-shebangs
-          name: Check that executables have shebangs
-        - id: check-json
-          name: Check JSON files
-        - id: check-merge-conflict
-          name: Check for merge conflicts
-        - id: check-symlinks
-          name: Check for broken symlinks
-        - id: check-toml
-          name: Check TOML files
-        - id: check-yaml
-          name: Check YAML files
-        - id: codespell
-          name: Check code for common misspellings
-        - id: debug-statements
-          name: Debug Statements and imports (Python)
-        - id: detect-private-key
-          name: Detect Private Keys
-        - id: end-of-file-fixer
-          name: Check End of Files
-        - id: fix-byte-order-marker
-          name: Check UTF-8 byte order marker
-        - id: isort
-          name: Check imports are sorted
-        - id: poetry
-          name: Check pyproject file
-        - id: pyupgrade
-          name: Check for upgradable syntax
-        - id: pytest
-          name: Test with pytest
-        - id: ruff
-          name: Lint with ruff
-        - id: trailing-whitespace
-          name: Trim Trailing Whitespace
-        - id: vulture
-          name: Find unused code
+          - id: bandit
+            name: Check with bandit
+          - id: black
+            name: Check code style
+          - id: blacken-docs
+            name: Check code style in documentation
+          - id: check-ast
+            name: Check Python AST
+          - id: check-case-conflict
+            name: Check for case conflicts
+          - id: check-docstring-first
+            name: Check docstring is first
+          - id: check-executables-have-shebangs
+            name: Check that executables have shebangs
+          - id: check-json
+            name: Check JSON files
+          - id: check-merge-conflict
+            name: Check for merge conflicts
+          - id: check-symlinks
+            name: Check for broken symlinks
+          - id: check-toml
+            name: Check TOML files
+          - id: check-yaml
+            name: Check YAML files
+          - id: codespell
+            name: Check code for common misspellings
+          - id: debug-statements
+            name: Debug Statements and imports (Python)
+          - id: detect-private-key
+            name: Detect Private Keys
+          - id: end-of-file-fixer
+            name: Check End of Files
+          - id: fix-byte-order-marker
+            name: Check UTF-8 byte order marker
+          - id: isort
+            name: Check imports are sorted
+          - id: poetry
+            name: Check pyproject file
+          - id: pyupgrade
+            name: Check for upgradable syntax
+          - id: pytest
+            name: Test with pytest
+          - id: ruff
+            name: Lint with ruff
+          - id: trailing-whitespace
+            name: Trim Trailing Whitespace
+          - id: vulture
+            name: Find unused code
 
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
-      with:
-        egress-policy: block
-        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
-          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
-    - name: Check out code from GitHub
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0   # v7.0.0
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+        with:
+          egress-policy: block
+          allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\nsonarcloud.io:443\nobjects.githubusercontent.com:443\n\nuploads.github.com:443\nupload.pypi.org:443\ntest.pypi.org:443\ncodecov.io:443\nuploader.codecov.io:443"
+      - name: Check out code from GitHub
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-    - name: Set up Python 3.13
-      id: python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405   # v5.5.0
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python 3.13
+        id: python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5.5.0
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Get pip cache dir
-      run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
+      - name: Get pip cache dir
+        run: echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
 
-    - name: Restore cached Python PIP packages
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9   # v6.1.0
-      with:
-        path: ${{ env.PIP_CACHE_DIR }}
-        key: pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version 
-          }}-${{ hashFiles('poetry.lock') }}
-        restore-keys: |
-          pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
-          pip-${{ runner.os }}-v1-
+      - name: Restore cached Python PIP packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.PIP_CACHE_DIR }}
+          key: pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
+            pip-${{ runner.os }}-v1-
 
-    - name: Install workflow dependencies
-      run: |
-        pip install poetry
-        poetry config virtualenvs.create true
-        poetry config virtualenvs.in-project true
+      - name: Install workflow dependencies
+        run: |
+          pip install poetry
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
 
-    - name: Restore cached Python virtual environment
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9   # v6.1.0
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version 
-          }}-${{ hashFiles('poetry.lock') }}
-        restore-keys: |
-          venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
-          venv-${{ runner.os }}-v1-
+      - name: Restore cached Python virtual environment
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
+            venv-${{ runner.os }}-v1-
 
-    - name: Install Python dependencies
-      run: poetry install --no-interaction --with=dev
+      - name: Install Python dependencies
+        run: poetry install --no-interaction --with=dev
 
-    - name: Check poetry.lock is up to date
-      run: poetry check --lock
+      - name: Check poetry.lock is up to date
+        run: poetry check --lock
 
-    - name: Run pre-commit migrate-config
-      run: poetry run pre-commit migrate-config
+      - name: Run pre-commit migrate-config
+        run: poetry run pre-commit migrate-config
 
-    - name: Install pre-commit hooks
-      run: poetry run pre-commit install
+      - name: Install pre-commit hooks
+        run: poetry run pre-commit install
 
-    - name: Run ${{ matrix.name }}
-      run: poetry run pre-commit run ${{ matrix.id }} --all-files --hook-stage 
-        manual
+      - name: Run ${{ matrix.name }}
+        run: poetry run pre-commit run ${{ matrix.id }} --all-files --hook-stage manual

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,7 +3,7 @@ name: Publish to PyPI on Version Tag
 on:
   push:
     tags:
-      - 'v*.*.*'  # Only run when a version tag is pushed
+    - 'v*.*.*'    # Only run when a version tag is pushed
 
 permissions:
   id-token: write  # Required for OIDC
@@ -11,6 +11,8 @@ permissions:
 
 jobs:
   build-and-publish:
+    permissions:
+      contents: read
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
     environment: pypi  # Optional but recommended for security
@@ -21,37 +23,43 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
+    - name: Harden Runner
+      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+      with:
+        egress-policy: block
+        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
+          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
 
       # - name: List available Python versions
       #   run: pyenv install --list
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
+      with:
+        python-version: ${{ matrix.python-version }}
 
-      - name: Cache pip
-        uses: actions/cache@v6.1.0
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+    - name: Cache pip
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # @v6.1.0
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
 
-      - name: Install build tools
-        run: |
-          python -m pip install --upgrade pip build
+    - name: Install build tools
+      run: |
+        python -m pip install --upgrade pip build
 
-      - name: Build the package
-        run: python -m build
+    - name: Build the package
+      run: python -m build
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://upload.pypi.org/legacy/  # Change to test.pypi.org for testing
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # @release/v1
+      with:
+        repository-url: https://upload.pypi.org/legacy/    # Change to test.pypi.org for testing
           # repository-url: https://test.pypi.org/legacy/
 
-      - name: Verify package metadata
-        run: python -m pip install --upgrade twine && twine check dist/*
+    - name: Verify package metadata
+      run: python -m pip install --upgrade twine && twine check dist/*

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,7 +3,7 @@ name: Publish to PyPI on Version Tag
 on:
   push:
     tags:
-    - 'v*.*.*'    # Only run when a version tag is pushed
+      - 'v*.*.*'  # Only run when a version tag is pushed
 
 permissions:
   id-token: write  # Required for OIDC
@@ -23,43 +23,42 @@ jobs:
       fail-fast: false
 
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
-      with:
-        egress-policy: block
-        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
-          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
-    - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+        with:
+          egress-policy: block
+          allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\nsonarcloud.io:443\nobjects.githubusercontent.com:443\n\nuploads.github.com:443\nupload.pypi.org:443\ntest.pypi.org:443\ncodecov.io:443\nuploader.codecov.io:443"
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
 
       # - name: List available Python versions
       #   run: pyenv install --list
 
-    - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Cache pip
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # @v6.1.0
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
+      - name: Cache pip
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # @v6.1.0
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
-    - name: Install build tools
-      run: |
-        python -m pip install --upgrade pip build
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip build
 
-    - name: Build the package
-      run: python -m build
+      - name: Build the package
+        run: python -m build
 
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # @release/v1
-      with:
-        repository-url: https://upload.pypi.org/legacy/    # Change to test.pypi.org for testing
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # @release/v1
+        with:
+          repository-url: https://upload.pypi.org/legacy/  # Change to test.pypi.org for testing
           # repository-url: https://test.pypi.org/legacy/
 
-    - name: Verify package metadata
-      run: python -m pip install --upgrade twine && twine check dist/*
+      - name: Verify package metadata
+        run: python -m pip install --upgrade twine && twine check dist/*

--- a/.github/workflows/pyupgrade.yml
+++ b/.github/workflows/pyupgrade.yml
@@ -1,54 +1,64 @@
 name: Run Pyupgrade and Auto-Commit
 
+permissions:
+  contents: read
 on:
   push:
     branches:
-      - main
+    - main
   pull_request:
     branches:
-      - main
+    - main
 
 jobs:
   pyupgrade:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
+    - name: Harden Runner
+      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+      with:
+        egress-policy: block
+        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
+          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
+    - name: Checkout repository
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
+      with:
+        python-version: "3.12"
 
-      - name: Cache Poetry dependencies
-        uses: actions/cache@v6.1.0
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-cache-
+    - name: Cache Poetry dependencies
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # @v6.1.0
+      with:
+        path: ~/.cache/pypoetry
+        key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-poetry-cache-
 
-      - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
+    - name: Install Poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | python3 -
 
-      - name: Regenerate poetry.lock and install dependencies
-        run: |
-          poetry lock
-          poetry install
+    - name: Regenerate poetry.lock and install dependencies
+      run: |
+        poetry lock
+        poetry install
 
-      - name: Install dependencies
-        run: poetry install
+    - name: Install dependencies
+      run: poetry install
 
-      - name: Run Pyupgrade with pre-commit
-        run: |
-          poetry run pre-commit run pyupgrade --all-files || true
+    - name: Run Pyupgrade with pre-commit
+      run: |
+        poetry run pre-commit run pyupgrade --all-files || true
 
-      - name: Commit and Push Changes
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git diff --quiet && git diff --staged --quiet || git commit -m "Apply pyupgrade changes"
-          git push
+    - name: Commit and Push Changes
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git add .
+        git diff --quiet && git diff --staged --quiet || git commit -m "Apply pyupgrade changes"
+        git push

--- a/.github/workflows/pyupgrade.yml
+++ b/.github/workflows/pyupgrade.yml
@@ -5,10 +5,10 @@ permissions:
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
+      - main
 
 jobs:
   pyupgrade:
@@ -17,48 +17,47 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
-      with:
-        egress-policy: block
-        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
-          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
-    - name: Checkout repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+        with:
+          egress-policy: block
+          allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\nsonarcloud.io:443\nobjects.githubusercontent.com:443\n\nuploads.github.com:443\nupload.pypi.org:443\ntest.pypi.org:443\ncodecov.io:443\nuploader.codecov.io:443"
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
 
-    - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
-      with:
-        python-version: "3.12"
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
+        with:
+          python-version: "3.12"
 
-    - name: Cache Poetry dependencies
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # @v6.1.0
-      with:
-        path: ~/.cache/pypoetry
-        key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-poetry-cache-
+      - name: Cache Poetry dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # @v6.1.0
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-cache-
 
-    - name: Install Poetry
-      run: |
-        curl -sSL https://install.python-poetry.org | python3 -
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
 
-    - name: Regenerate poetry.lock and install dependencies
-      run: |
-        poetry lock
-        poetry install
+      - name: Regenerate poetry.lock and install dependencies
+        run: |
+          poetry lock
+          poetry install
 
-    - name: Install dependencies
-      run: poetry install
+      - name: Install dependencies
+        run: poetry install
 
-    - name: Run Pyupgrade with pre-commit
-      run: |
-        poetry run pre-commit run pyupgrade --all-files || true
+      - name: Run Pyupgrade with pre-commit
+        run: |
+          poetry run pre-commit run pyupgrade --all-files || true
 
-    - name: Commit and Push Changes
-      run: |
-        git config --global user.name "github-actions[bot]"
-        git config --global user.email "github-actions[bot]@users.noreply.github.com"
-        git add .
-        git diff --quiet && git diff --staged --quiet || git commit -m "Apply pyupgrade changes"
-        git push
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git diff --quiet && git diff --staged --quiet || git commit -m "Apply pyupgrade changes"
+          git push

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,10 +1,9 @@
----
 name: Release Drafter
 
 on:
   push:
     branches:
-      - main
+    - main
 
 permissions:
   contents: write
@@ -12,10 +11,19 @@ permissions:
 
 jobs:
   update_release_draft:
+    permissions:
+      contents: read
     name: Draft release
     runs-on: ubuntu-latest
     steps:
-      - name: Run Release Drafter
-        uses: release-drafter/release-drafter@v7.5.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Harden Runner
+      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+      with:
+        egress-policy: block
+        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
+          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
+    - name: Run Release Drafter
+      uses: 
+        release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-    - main
+      - main
 
 permissions:
   contents: write
@@ -12,18 +12,16 @@ permissions:
 jobs:
   update_release_draft:
     permissions:
-      contents: read
+      contents: write
     name: Draft release
     runs-on: ubuntu-latest
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
-      with:
-        egress-policy: block
-        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
-          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
-    - name: Run Release Drafter
-      uses: 
-        release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+        with:
+          egress-policy: block
+          allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\nsonarcloud.io:443\nobjects.githubusercontent.com:443\n\nuploads.github.com:443\nupload.pypi.org:443\ntest.pypi.org:443\ncodecov.io:443\nuploader.codecov.io:443"
+      - name: Run Release Drafter
+        uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,61 +1,72 @@
----
 name: Release
 
 # yamllint disable-line rule:truthy
+permissions:
+  contents: read
 on:
   release:
     types:
-      - published
+    - published
 
 jobs:
   release:
+    permissions:
+      contents: read
     name: Releasing to PyPi
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v7
-      - name: Set up Python 3.12
-        id: python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-      - name: Get pip cache dir
-        id: pip-cache
-        run: |
-          echo "::set-output name=dir::$(pip cache dir)"
-      - name: Restore cached Python PIP packages
-        uses: actions/cache@v6.1.0
-        with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-${{ hashFiles('.github/workflows/requirements.txt') }}
-          restore-keys: |
-            pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
-      - name: Install workflow dependencies
-        run: |
-          pip install -r .github/workflows/requirements.txt
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project true
-      - name: Restore cached Python virtual environment
-        id: cached-poetry-dependencies
-        uses: actions/cache@v6.1.0
-        with:
-          path: .venv
-          key: >-
-            venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
-            venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
-      - name: Install dependencies
-        run: poetry install --no-interaction
-      - name: Set package version
-        run: |
-          version="${{ github.event.release.tag_name }}"
-          version="${version,,}"
-          version="${version#v}"
-          poetry version --no-interaction "${version}"
-      - name: Build package
-        run: poetry build --no-interaction
-      - name: Publish to PyPi
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          poetry config pypi-token.pypi "${PYPI_TOKEN}"
-          poetry publish --no-interaction
+    - name: Harden Runner
+      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+      with:
+        egress-policy: block
+        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
+          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
+    - name: Check out code from GitHub
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
+    - name: Set up Python 3.12
+      id: python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
+      with:
+        python-version: '3.12'
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+    - name: Restore cached Python PIP packages
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # @v6.1.0
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version 
+          }}-${{ hashFiles('.github/workflows/requirements.txt') }}
+        restore-keys: |
+          pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
+    - name: Install workflow dependencies
+      run: |
+        pip install -r .github/workflows/requirements.txt
+        poetry config virtualenvs.create true
+        poetry config virtualenvs.in-project true
+    - name: Restore cached Python virtual environment
+      id: cached-poetry-dependencies
+      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # @v6.1.0
+      with:
+        path: .venv
+        key: >-
+          venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-${{
+          hashFiles('poetry.lock') }}
+          venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
+    - name: Install dependencies
+      run: poetry install --no-interaction
+    - name: Set package version
+      run: |
+        version="${{ github.event.release.tag_name }}"
+        version="${version,,}"
+        version="${version#v}"
+        poetry version --no-interaction "${version}"
+    - name: Build package
+      run: poetry build --no-interaction
+    - name: Publish to PyPi
+      env:
+        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        poetry config pypi-token.pypi "${PYPI_TOKEN}"
+        poetry publish --no-interaction

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ permissions:
 on:
   release:
     types:
-    - published
+      - published
 
 jobs:
   release:
@@ -15,58 +15,56 @@ jobs:
     name: Releasing to PyPi
     runs-on: ubuntu-latest
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
-      with:
-        egress-policy: block
-        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
-          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
-    - name: Check out code from GitHub
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
-    - name: Set up Python 3.12
-      id: python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
-      with:
-        python-version: '3.12'
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"
-    - name: Restore cached Python PIP packages
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # @v6.1.0
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version 
-          }}-${{ hashFiles('.github/workflows/requirements.txt') }}
-        restore-keys: |
-          pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
-    - name: Install workflow dependencies
-      run: |
-        pip install -r .github/workflows/requirements.txt
-        poetry config virtualenvs.create true
-        poetry config virtualenvs.in-project true
-    - name: Restore cached Python virtual environment
-      id: cached-poetry-dependencies
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # @v6.1.0
-      with:
-        path: .venv
-        key: >-
-          venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-${{
-          hashFiles('poetry.lock') }}
-          venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
-    - name: Install dependencies
-      run: poetry install --no-interaction
-    - name: Set package version
-      run: |
-        version="${{ github.event.release.tag_name }}"
-        version="${version,,}"
-        version="${version#v}"
-        poetry version --no-interaction "${version}"
-    - name: Build package
-      run: poetry build --no-interaction
-    - name: Publish to PyPi
-      env:
-        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        poetry config pypi-token.pypi "${PYPI_TOKEN}"
-        poetry publish --no-interaction
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+        with:
+          egress-policy: block
+          allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\nsonarcloud.io:443\nobjects.githubusercontent.com:443\n\nuploads.github.com:443\nupload.pypi.org:443\ntest.pypi.org:443\ncodecov.io:443\nuploader.codecov.io:443"
+      - name: Check out code from GitHub
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
+      - name: Set up Python 3.12
+        id: python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
+        with:
+          python-version: '3.12'
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+      - name: Restore cached Python PIP packages
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # @v6.1.0
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-${{ hashFiles('.github/workflows/requirements.txt') }}
+          restore-keys: |
+            pip-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
+      - name: Install workflow dependencies
+        run: |
+          pip install -r .github/workflows/requirements.txt
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
+      - name: Restore cached Python virtual environment
+        id: cached-poetry-dependencies
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # @v6.1.0
+        with:
+          path: .venv
+          key: >-
+            venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-${{
+            hashFiles('poetry.lock') }}
+            venv-${{ runner.os }}-v1-${{ steps.python.outputs.python-version }}-
+      - name: Install dependencies
+        run: poetry install --no-interaction
+      - name: Set package version
+        run: |
+          version="${{ github.event.release.tag_name }}"
+          version="${version,,}"
+          version="${version#v}"
+          poetry version --no-interaction "${version}"
+      - name: Build package
+        run: poetry build --no-interaction
+      - name: Publish to PyPi
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          poetry config pypi-token.pypi "${PYPI_TOKEN}"
+          poetry publish --no-interaction

--- a/.github/workflows/run_query.yml
+++ b/.github/workflows/run_query.yml
@@ -13,7 +13,7 @@ permissions:
 on:
   workflow_dispatch:  # Allows manual triggering
   schedule:
-  - cron: '0 6 * * *'    # Every day at 06:00 UTC
+    - cron: '0 6 * * *'  # Every day at 06:00 UTC
 
 jobs:
   run-query:
@@ -25,48 +25,47 @@ jobs:
         python-version: ['3.12', '3.13', '3.14']
 
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
-      with:
-        egress-policy: block
-        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
-          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
-    - name: Checkout Repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+        with:
+          egress-policy: block
+          allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\nsonarcloud.io:443\nobjects.githubusercontent.com:443\n\nuploads.github.com:443\nupload.pypi.org:443\ntest.pypi.org:443\ncodecov.io:443\nuploader.codecov.io:443"
+      - name: Checkout Repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
+        with:
+          python-version: ${{ matrix.python-version }}
           # cache: poetry  # Caching voor snellere builds
 
-    - name: Install Poetry
-      run: |
-        curl -sSL https://install.python-poetry.org | python3 -
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        export PATH="$HOME/.local/bin:$PATH"
-        poetry --version
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$PATH"
+          poetry --version
 
-    - name: Configure Poetry
-      run: |
-        poetry config virtualenvs.in-project true
-        poetry --version
-        poetry lock
+      - name: Configure Poetry
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry --version
+          poetry lock
 
-    - name: Install Dependencies with Poetry
-      run: |
-        # poetry add ./python-frank-energie --dev --editable
-        poetry install --no-interaction
-        pip install -e ./  # Install the current repository as an editable package
+      - name: Install Dependencies with Poetry
+        run: |
+          # poetry add ./python-frank-energie --dev --editable
+          poetry install --no-interaction
+          pip install -e ./  # Install the current repository as an editable package
 
-    - name: Execute Frank Energie Query
-      run: |
-        mkdir -p logs
-        poetry run python scripts/test_query.py 2>&1 | tee logs/output_${{ matrix.python-version }}.log
+      - name: Execute Frank Energie Query
+        run: |
+          mkdir -p logs
+          poetry run python scripts/test_query.py 2>&1 | tee logs/output_${{ matrix.python-version }}.log
 
-    - name: Upload Log Artifact
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v7
-      if: always()
-      with:
-        name: frank-energie-logs-${{ matrix.python-version }}
-        path: logs/
+      - name: Upload Log Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v7
+        if: always()
+        with:
+          name: frank-energie-logs-${{ matrix.python-version }}
+          path: logs/

--- a/.github/workflows/run_query.yml
+++ b/.github/workflows/run_query.yml
@@ -8,55 +8,65 @@
 # The workflow is defined in YAML format and includes a series of steps that are executed sequentially.
 name: Run Frank Energie Query
 
+permissions:
+  contents: read
 on:
   workflow_dispatch:  # Allows manual triggering
   schedule:
-    - cron: '0 6 * * *'  # Every day at 06:00 UTC
+  - cron: '0 6 * * *'    # Every day at 06:00 UTC
 
 jobs:
   run-query:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12','3.13','3.14']
+        python-version: ['3.12', '3.13', '3.14']
 
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v7
+    - name: Harden Runner
+      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+      with:
+        egress-policy: block
+        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
+          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
+    - name: Checkout Repository
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
+      with:
+        python-version: ${{ matrix.python-version }}
           # cache: poetry  # Caching voor snellere builds
 
-      - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          export PATH="$HOME/.local/bin:$PATH"
-          poetry --version
+    - name: Install Poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | python3 -
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        export PATH="$HOME/.local/bin:$PATH"
+        poetry --version
 
-      - name: Configure Poetry
-        run: |
-          poetry config virtualenvs.in-project true
-          poetry --version
-          poetry lock
+    - name: Configure Poetry
+      run: |
+        poetry config virtualenvs.in-project true
+        poetry --version
+        poetry lock
 
-      - name: Install Dependencies with Poetry
-        run: |
-          # poetry add ./python-frank-energie --dev --editable
-          poetry install --no-interaction
-          pip install -e ./  # Install the current repository as an editable package
+    - name: Install Dependencies with Poetry
+      run: |
+        # poetry add ./python-frank-energie --dev --editable
+        poetry install --no-interaction
+        pip install -e ./  # Install the current repository as an editable package
 
-      - name: Execute Frank Energie Query
-        run: |
-          mkdir -p logs
-          poetry run python scripts/test_query.py 2>&1 | tee logs/output_${{ matrix.python-version }}.log
+    - name: Execute Frank Energie Query
+      run: |
+        mkdir -p logs
+        poetry run python scripts/test_query.py 2>&1 | tee logs/output_${{ matrix.python-version }}.log
 
-      - name: Upload Log Artifact
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: frank-energie-logs-${{ matrix.python-version }}
-          path: logs/
+    - name: Upload Log Artifact
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v7
+      if: always()
+      with:
+        name: frank-energie-logs-${{ matrix.python-version }}
+        path: logs/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,17 @@
 name: Run Tests
 
+permissions:
+  contents: read
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
 
 jobs:
   tests:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     env:
@@ -16,43 +20,49 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.12", "3.13", "3.14" ]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
+    - name: Harden Runner
+      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+      with:
+        egress-policy: block
+        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
+          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
+    - name: Checkout repository
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
+      with:
+        python-version: ${{ matrix.python-version }}
 
-      - name: Install Poetry (if you use poetry)
-        run: pip install poetry
+    - name: Install Poetry (if you use poetry)
+      run: pip install poetry
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .
-          pip install aresponses pytest pytest-asyncio pytest-homeassistant-custom-component
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -e .
+        pip install aresponses pytest pytest-asyncio pytest-homeassistant-custom-component
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
 
-      - name: Uninstall pytest-socket
-        run: pip uninstall -y pytest-socket || true
+    - name: Uninstall pytest-socket
+      run: pip uninstall -y pytest-socket || true
 
-      - name: Run pytest with coverage
-        run: |
-          PYTHONPATH=. pytest \
-            --asyncio-mode=auto \
-            --disable-warnings \
-            --maxfail=1 \
-            --cov=frank_energie \
-            --cov-report=xml \
-            tests/
+    - name: Run pytest with coverage
+      run: |
+        PYTHONPATH=. pytest \
+          --asyncio-mode=auto \
+          --disable-warnings \
+          --maxfail=1 \
+          --cov=frank_energie \
+          --cov-report=xml \
+          tests/
 
-      - name: Upload coverage report
-        uses: codecov/codecov-action@v7
-        with:
-          files: ./coverage.xml
-          fail_ci_if_error: false
+    - name: Upload coverage report
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # @v7
+      with:
+        files: ./coverage.xml
+        fail_ci_if_error: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,46 +23,45 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
-      with:
-        egress-policy: block
-        allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\n\
-          sonarcloud.io:443\nobjects.githubusercontent.com:443\n"
-    - name: Checkout repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # @v2.8.1
+        with:
+          egress-policy: block
+          allowed-endpoints: "api.github.com:443\ngithub.com:443\npypi.org:443\nfiles.pythonhosted.org:443\nsonarcloud.io:443\nobjects.githubusercontent.com:443\n\nuploads.github.com:443\nupload.pypi.org:443\ntest.pypi.org:443\ncodecov.io:443\nuploader.codecov.io:443"
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # @v7
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v6
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install Poetry (if you use poetry)
-      run: pip install poetry
+      - name: Install Poetry (if you use poetry)
+        run: pip install poetry
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .
-        pip install aresponses pytest pytest-asyncio pytest-homeassistant-custom-component
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          pip install aresponses pytest pytest-asyncio pytest-homeassistant-custom-component
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
 
-    - name: Uninstall pytest-socket
-      run: pip uninstall -y pytest-socket || true
+      - name: Uninstall pytest-socket
+        run: pip uninstall -y pytest-socket || true
 
-    - name: Run pytest with coverage
-      run: |
-        PYTHONPATH=. pytest \
-          --asyncio-mode=auto \
-          --disable-warnings \
-          --maxfail=1 \
-          --cov=frank_energie \
-          --cov-report=xml \
-          tests/
+      - name: Run pytest with coverage
+        run: |
+          PYTHONPATH=. pytest \
+            --asyncio-mode=auto \
+            --disable-warnings \
+            --maxfail=1 \
+            --cov=frank_energie \
+            --cov-report=xml \
+            tests/
 
-    - name: Upload coverage report
-      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # @v7
-      with:
-        files: ./coverage.xml
-        fail_ci_if_error: false
+      - name: Upload coverage report
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # @v7
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false

--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -285,7 +285,7 @@ class FrankEnergie:
         _LOGGER.debug(
             "Executing GraphQL operation [%s] with variables: %s",
             operation_name,
-            self._last_variables,
+            list(self._last_variables.keys()) if self._last_variables else None,
         )
 
         await self._ensure_session()

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -1244,7 +1244,7 @@ class Address:
             city = " ".join(parts[1:])
             return zip_code, city
 
-        _LOGGER.debug("Unexpected postcode/city format: %s", value)
+        _LOGGER.debug("Unexpected postcode/city format")
         return value, ""
 
 


### PR DESCRIPTION
## Summary
This pull request introduces critical security hardening for our GitHub Actions workflows and mitigates clear-text logging issues identified by Code Scanning.

## Key Changes
- **Harden Runner**: Hardens GitHub Actions workflows by injecting `step-security/harden-runner` in `egress-policy: block` mode with scoped endpoints.
- **Workflow Permissions**: Enforces strict workflow permissions at both global (`contents: read`) and job levels.
- **Action Pinning**: Pins all third-party GitHub Actions to their exact 40-character commit hashes for supply chain security.
- **Code Scanning Fixes**: Mitigates Code Scanning alerts for clear-text logging of potentially sensitive data (GraphQL variables and location data).

## Why this is needed
To adhere to our zero-trust requirements and address the security alerts reported by dependabot and GitHub Code Scanning.

## Summary by Sourcery

Versterk GitHub Actions-workflows en verminder het loggen van mogelijk gevoelige gegevens.

Bugfixes:
- Voorkom het loggen van de volledige GraphQL-variabelenpayload door alleen variabelesleutels te loggen bij het uitvoeren van operaties.
- Verwijder mogelijk gevoelige postcode/stadswaarden uit debuglogs, terwijl diagnostische informatie over onverwachte formats behouden blijft.

CI:
- Voeg een step-security geharde runner met beperkte egress toe aan alle CI-, test-, release-, labeler-, Dependabot-, release-drafter- en utility-workflows.
- Stel strengere standaard- en per-job GitHub Actions-permissies in (voornamelijk `contents: read`) en pin alle third-party actions aan specifieke commit-SHA’s voor supply-chain-beveiliging.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden GitHub Actions workflows and reduce logging of potentially sensitive data.

Bug Fixes:
- Avoid logging full GraphQL variables payload by logging only variable keys when executing operations.
- Remove potentially sensitive postcode/city value from debug logs while retaining unexpected-format diagnostics.

CI:
- Add step-security hardened runner with restricted egress to all CI, test, release, labeler, Dependabot, release-drafter, and utility workflows.
- Set stricter default and per-job GitHub Actions permissions (primarily contents: read) and pin all third-party actions to specific commit SHAs for supply-chain security.

</details>