### PR TITLE
Fix CI workflows checking wrong directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,12 @@ jobs:
 
       - name: Type check (mypy)
         run: |
-          mypy custom_components
+          mypy python_frank_energie
 
       - name: Run tests with coverage
         run: |
           pytest \
-            --cov=custom_components \
+            --cov=python_frank_energie \
             --cov-report=xml \
             --cov-report=term-missing
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
             --asyncio-mode=auto \
             --disable-warnings \
             --maxfail=1 \
-            --cov=frank_energie \
+            --cov=python_frank_energie \
             --cov-report=xml \
             tests/
 


### PR DESCRIPTION
Update ci.yml and tests.yml to point to python_frank_energie instead of custom_components and frank_energie, allowing mypy and coverage to run against the actual source code.

## Summary by Sourcery

Werk CI-workflows bij om typechecking en test coverage uit te voeren tegen het juiste `python_frank_energie`-pakket.

CI:
- Wijs mypy in de CI-workflow naar het `python_frank_energie`-pakket in plaats van naar `custom_components`.
- Werk de coverageconfiguratie in de CI- en testworkflows bij om `python_frank_energie` te meten in plaats van `custom_components/frank_energie`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update CI workflows to run type checking and test coverage against the correct python_frank_energie package.

CI:
- Point mypy in ci workflow to the python_frank_energie package instead of custom_components.
- Update coverage configuration in ci and tests workflows to measure python_frank_energie instead of custom_components/frank_energie.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated type-checking and test coverage collection to reflect the current package structure.
  * Improved the accuracy of coverage reporting for the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->