### PR TITLE
fix: correct labeler permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,12 +9,12 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   labeler:
     permissions:
       contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Beperk schrijfrechten voor pull requests in de labeler-workflow tot de labeler-taak in plaats van machtigingen op workflowniveau.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Limit pull request write permissions in the labeler workflow to the labeler job instead of the workflow-level permissions.

</details>