### PR TITLE
fix: derive PriceData.resolution_minutes from entry timestamps instead of defaulting to 60

### DIFF
--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -2942,27 +2942,34 @@ class PriceData:
         # Every PriceData construction site (live API fetch, BE parsing,
         # cache restore) goes through here, so this is the single place
         # that guarantees resolution_minutes actually matches the data.
-        first = self.price_data[0] if self.price_data else None
-        if first is not None and first.date_from and first.date_till:
-            derived_minutes = int((first.date_till - first.date_from).total_seconds() // 60)
-            if derived_minutes > 0:
-                self.resolution_minutes = derived_minutes
-                _LOGGER.debug(
-                    "PriceData(%s): derived resolution_minutes=%s from entry spacing",
-                    self.energy_type,
-                    derived_minutes,
-                )
-            else:
-                _LOGGER.debug(
-                    "PriceData(%s): non-positive interval (%s min) between "
-                    "date_from/date_till, keeping resolution_minutes=%s",
-                    self.energy_type,
-                    derived_minutes,
-                    self.resolution_minutes,
-                )
+        # Checked across every entry (not just the first) so one malformed
+        # or outlier entry can't silently determine the whole series'
+        # resolution; the smallest positive interval wins.
+        intervals = [
+            int((price.date_till - price.date_from).total_seconds() // 60)
+            for price in self.price_data
+            if price.date_from and price.date_till
+        ]
+        positive_intervals = [minutes for minutes in intervals if minutes > 0]
+        if positive_intervals:
+            derived_minutes = min(positive_intervals)
+            self.resolution_minutes = derived_minutes
+            _LOGGER.debug(
+                "PriceData(%s): derived resolution_minutes=%s from entry spacing",
+                self.energy_type,
+                derived_minutes,
+            )
+        elif intervals:
+            _LOGGER.debug(
+                "PriceData(%s): no positive interval among %s entries with "
+                "date_from/date_till, keeping resolution_minutes=%s",
+                self.energy_type,
+                len(intervals),
+                self.resolution_minutes,
+            )
         elif self.price_data:
             _LOGGER.debug(
-                "PriceData(%s): first entry missing date_from/date_till, keeping resolution_minutes=%s",
+                "PriceData(%s): no entries with both date_from/date_till, keeping resolution_minutes=%s",
                 self.energy_type,
                 self.resolution_minutes,
             )

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -2937,6 +2937,36 @@ class PriceData:
         """Convert raw API dicts to typed Price objects."""
         self.price_data: list[Price] = [Price({**p, "energy_type": self.energy_type}) for p in self.prices]
 
+        # Derive the real interval length from the data itself rather than
+        # trusting the `resolution_minutes` default/caller-supplied value.
+        # Every PriceData construction site (live API fetch, BE parsing,
+        # cache restore) goes through here, so this is the single place
+        # that guarantees resolution_minutes actually matches the data.
+        first = self.price_data[0] if self.price_data else None
+        if first is not None and first.date_from and first.date_till:
+            derived_minutes = int((first.date_till - first.date_from).total_seconds() // 60)
+            if derived_minutes > 0:
+                self.resolution_minutes = derived_minutes
+                _LOGGER.debug(
+                    "PriceData(%s): derived resolution_minutes=%s from entry spacing",
+                    self.energy_type,
+                    derived_minutes,
+                )
+            else:
+                _LOGGER.debug(
+                    "PriceData(%s): non-positive interval (%s min) between "
+                    "date_from/date_till, keeping resolution_minutes=%s",
+                    self.energy_type,
+                    derived_minutes,
+                    self.resolution_minutes,
+                )
+        elif self.price_data:
+            _LOGGER.debug(
+                "PriceData(%s): first entry missing date_from/date_till, keeping resolution_minutes=%s",
+                self.energy_type,
+                self.resolution_minutes,
+            )
+
     # ------------------------------------------------------------------ #
     # Dunder helpers                                                       #
     # ------------------------------------------------------------------ #

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -800,6 +800,46 @@ def test_price_data_derives_resolution_minutes_from_entry_spacing() -> None:
     assert PriceData([], energy_type="gas", resolution_minutes=15).resolution_minutes == 15
 
 
+def test_price_data_resolution_derivation_ignores_outlier_first_entry() -> None:
+    """A malformed/outlier first entry must not solely determine resolution_minutes.
+
+    Regression test: derivation previously only inspected price_data[0], so a
+    single irregular first entry (e.g. a 60-minute span in an otherwise PT15M
+    series) would silently set the wrong resolution for the whole series.
+    Derivation now takes the smallest positive interval across all entries.
+    """
+    from python_frank_energie.models import PriceData
+
+    irregular = [
+        {
+            "from": "2026-07-19T22:00:00.000Z",
+            "till": "2026-07-19T23:00:00.000Z",  # outlier: 60 minutes
+            "marketPrice": 0.1,
+            "marketPriceTax": 0.02,
+            "sourcingMarkupPrice": 0.01,
+            "energyTaxPrice": 0.1,
+        },
+        {
+            "from": "2026-07-19T23:00:00.000Z",
+            "till": "2026-07-19T23:15:00.000Z",  # 15 minutes
+            "marketPrice": 0.1,
+            "marketPriceTax": 0.02,
+            "sourcingMarkupPrice": 0.01,
+            "energyTaxPrice": 0.1,
+        },
+        {
+            "from": "2026-07-19T23:15:00.000Z",
+            "till": "2026-07-19T23:30:00.000Z",  # 15 minutes
+            "marketPrice": 0.1,
+            "marketPriceTax": 0.02,
+            "sourcingMarkupPrice": 0.01,
+            "energyTaxPrice": 0.1,
+        },
+    ]
+
+    assert PriceData(irregular, energy_type="electricity").resolution_minutes == 15
+
+
 def test_market_prices_from_dict_derives_resolution_minutes() -> None:
     """MarketPrices.from_dict must produce PriceData with the correct resolution.
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -750,3 +750,90 @@ def test_price_data_add_validates_metadata() -> None:
 
     with pytest.raises(ValueError, match="Cannot merge PriceData with different energy types"):
         _ = left + right_diff_type
+
+
+def test_price_data_derives_resolution_minutes_from_entry_spacing() -> None:
+    """PriceData must derive resolution_minutes from the actual entry spacing.
+
+    Regression test: PriceData previously always defaulted resolution_minutes
+    to 60, regardless of the real interval length of the price entries it was
+    constructed from. This made every live-fetched PT15M price series silently
+    report itself as PT60M, which broke downstream resolution-validity checks
+    (e.g. in the Home Assistant integration's disk-cache freshness check).
+    """
+    from python_frank_energie.models import PriceData
+
+    quarter_hourly = [
+        {
+            "from": "2026-07-19T22:00:00.000Z",
+            "till": "2026-07-19T22:15:00.000Z",
+            "marketPrice": 0.1,
+            "marketPriceTax": 0.02,
+            "sourcingMarkupPrice": 0.01,
+            "energyTaxPrice": 0.1,
+        },
+        {
+            "from": "2026-07-19T22:15:00.000Z",
+            "till": "2026-07-19T22:30:00.000Z",
+            "marketPrice": 0.1,
+            "marketPriceTax": 0.02,
+            "sourcingMarkupPrice": 0.01,
+            "energyTaxPrice": 0.1,
+        },
+    ]
+    hourly = [
+        {
+            "from": "2026-07-19T22:00:00.000Z",
+            "till": "2026-07-19T23:00:00.000Z",
+            "marketPrice": 0.1,
+            "marketPriceTax": 0.02,
+            "sourcingMarkupPrice": 0.01,
+            "energyTaxPrice": 0.1,
+        },
+    ]
+
+    assert PriceData(quarter_hourly, energy_type="electricity").resolution_minutes == 15
+    assert PriceData(hourly, energy_type="electricity").resolution_minutes == 60
+
+    # No entries to derive from: keeps the default / explicitly passed value.
+    assert PriceData([], energy_type="gas").resolution_minutes == 60
+    assert PriceData([], energy_type="gas", resolution_minutes=15).resolution_minutes == 15
+
+
+def test_market_prices_from_dict_derives_resolution_minutes() -> None:
+    """MarketPrices.from_dict must produce PriceData with the correct resolution.
+
+    Regression test for the real-world bug: a live PT15M marketPrices response
+    previously resulted in PriceData.resolution_minutes == 60 because
+    MarketPrices._parse_prices never passed resolution_minutes when
+    constructing PriceData.
+    """
+    response = {
+        "data": {
+            "marketPrices": {
+                "electricityPrices": [
+                    {
+                        "from": "2026-07-19T22:00:00.000Z",
+                        "till": "2026-07-19T22:15:00.000Z",
+                        "marketPrice": 0.1,
+                        "marketPriceTax": 0.02,
+                        "sourcingMarkupPrice": 0.01,
+                        "energyTaxPrice": 0.1,
+                    },
+                    {
+                        "from": "2026-07-19T22:15:00.000Z",
+                        "till": "2026-07-19T22:30:00.000Z",
+                        "marketPrice": 0.1,
+                        "marketPriceTax": 0.02,
+                        "sourcingMarkupPrice": 0.01,
+                        "energyTaxPrice": 0.1,
+                    },
+                ],
+                "gasPrices": [],
+            }
+        }
+    }
+
+    market_prices = MarketPrices.from_dict(response)
+
+    assert market_prices.electricity.resolution_minutes == 15


### PR DESCRIPTION
## Summary
- `PriceData.resolution_minutes` always defaulted to 60 minutes regardless of the actual data, because no construction site (live API fetch via `MarketPrices._parse_prices`, BE parsing, or disk-cache restore) ever set it based on the real interval length. Every PT15M price series silently reported itself as PT60M to downstream consumers.
- `PriceData.__post_init__` now derives `resolution_minutes` from the first entry's `date_till - date_from` spacing, covering every construction path in one place. Falls back to the default/explicitly-passed value when there are no entries to derive from (e.g. an empty gas series).
- Adds debug logging for the derivation and its fallback paths (missing timestamps, non-positive interval).

## Why this matters
Downstream consumers that validate resolution against a contract setting (e.g. the Home Assistant integration comparing `resolution_minutes` to a configured PT15M/PT60M contract) always saw a false mismatch for PT15M data, causing correctly-fetched prices to be treated as stale/invalid.

## Test plan
- `test_price_data_derives_resolution_minutes_from_entry_spacing` — 15-min and 60-min entry spacing derive correctly; empty series preserve the default/explicit value.
- `test_market_prices_from_dict_derives_resolution_minutes` — end-to-end regression through `MarketPrices.from_dict` with a realistic PT15M response.
- Full suite: 256 passed.
- Verified live against the real Frank Energie API in a Home Assistant dev environment — confirmed derived resolution now matches the real PT15M data instead of silently defaulting to 60.

## Summary by Sourcery

Leid de prijresolutie af uit de daadwerkelijke invoertijdstempels zodat PriceData over alle constructiepaden het juiste interval rapporteert.

Bug Fixes:
- Corrigeer PriceData.resolution_minutes zodat PT15M-series niet langer ten onrechte als uurlijks worden gerapporteerd en downstream-resolutiecontroles niet meer breken.

Enhancements:
- Voeg debuglogging toe rond de afleiding van resolution_minutes en de fallback wanneer tijdstempels ontbreken of ongeldig zijn.

Tests:
- Voeg regressietests toe om te garanderen dat PriceData resolution_minutes afleidt uit de afstand tussen entries en dat MarketPrices.from_dict correct opgeloste PriceData produceert voor PT15M-data.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Derive price resolution from actual entry timestamps so PriceData reports the correct interval length across all construction paths.

Bug Fixes:
- Correct PriceData.resolution_minutes so PT15M series no longer incorrectly report as hourly and break downstream resolution checks.

Enhancements:
- Add debug logging around resolution_minutes derivation and fallback when timestamps are missing or invalid.

Tests:
- Add regression tests to ensure PriceData derives resolution_minutes from entry spacing and MarketPrices.from_dict produces correctly-resolved PriceData for PT15M data.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of reported price intervals by deriving the resolution from the actual market data.
  * Correctly identifies 15-minute electricity pricing intervals instead of incorrectly reporting hourly intervals.
  * Preserves existing defaults when pricing data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->