### PR TITLE
fix: log Enode charger count at debug level instead of info

### DIFF
--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -823,7 +823,7 @@ class FrankEnergie:
                 _LOGGER.debug("No chargers found in data: %s", response)
                 return {}
             chargers_data = response.get("data", {}).get("enodeChargers", [])
-            _LOGGER.info("%s Enode Chargers Found", len(chargers_data))
+            _LOGGER.debug("%s Enode Chargers Found", len(chargers_data))
             _LOGGER.debug("Enode Chargers data: %s", chargers_data)
             # _LOGGER.debug("Format for 'enodeChargers' response: %s", type(response))
             # _LOGGER.debug("Format for 'enodeChargers' chargers: %s", type(chargers))


### PR DESCRIPTION
## Summary

- The Enode charger count (`"%s Enode Chargers Found"`) was logged at `info` level, but this fires on every poll — it's routine, expected output, not something a user needs surfaced by default.
- Dropped it to `debug`, consistent with the surrounding charger-fetch logging (the following line, `"Enode Chargers data: %s"`, was already debug).

## Test plan

- [x] No behavior change — logging level only.

## Samenvatting door Sourcery

Verbeteringen:
- Log het aantal Enode-laadstations op debugniveau in plaats van infoniveau om het in lijn te brengen met de omliggende logging voor het ophalen van laadstations.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Log the Enode charger count at debug level instead of info to align with surrounding charger fetch logging.

</details>