### PR TITLE
feat: add France (FR) market support

### DIFF
--- a/python_frank_energie/domain.py
+++ b/python_frank_energie/domain.py
@@ -20,6 +20,7 @@ class CountryCode(StrEnum):
 
     NL = "NL"
     BE = "BE"
+    FR = "FR"
 
 
 class Resolution(StrEnum):

--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -2215,19 +2215,25 @@ class FrankEnergie:
         raw = response.get("data", {}).get("me", {}).get("smartHvac")
         return SmartHvac.from_dict(raw)
 
-    async def be_prices(self, start_date: date | None = None, end_date: date | None = None) -> MarketPrices:
-        """Get belgium market prices."""
+    async def country_prices(
+        self,
+        country: str,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        resolution: str | None = "PT15M",
+    ) -> MarketPrices:
+        """Get market prices for a country served via the 'x-country' header (e.g. BE, FR)."""
         if start_date is None:
             start_date = datetime.now(UTC).date()
         if end_date is None:
             end_date = start_date + timedelta(days=1)
 
-        headers = {"x-country": "BE"}
+        headers = {"x-country": country}
 
         query = FrankEnergieQuery(
             """
-            query MarketPrices ($date: String!) {
-                marketPrices(date: $date) {
+            query MarketPrices ($date: String!, $resolution: PriceResolution!) {
+                marketPrices(date: $date, resolution: $resolution) {
                     electricityPrices {
                         from
                         till
@@ -2255,10 +2261,22 @@ class FrankEnergie:
             }
             """,
             "MarketPrices",
-            {"date": str(start_date)},
+            {"date": str(start_date), "resolution": resolution},
         )
         response = await self._query(query, extra_headers=headers)
-        return MarketPrices.from_be_dict(response)
+        return MarketPrices.from_country_dict(response, country)
+
+    async def be_prices(
+        self, start_date: date | None = None, end_date: date | None = None, resolution: str | None = "PT15M"
+    ) -> MarketPrices:
+        """Get belgium market prices."""
+        return await self.country_prices("BE", start_date, end_date, resolution)
+
+    async def fr_prices(
+        self, start_date: date | None = None, end_date: date | None = None, resolution: str | None = "PT15M"
+    ) -> MarketPrices:
+        """Get france market prices."""
+        return await self.country_prices("FR", start_date, end_date, resolution)
 
     async def prices(
         self,

--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -2282,7 +2282,6 @@ class FrankEnergie:
     async def prices(
         self,
         start_date: date | None = None,
-        end_date: date | None = None,
         resolution: PriceResolution = "PT15M",
     ) -> MarketPrices:
         """Get market prices."""

--- a/python_frank_energie/frank_energie.py
+++ b/python_frank_energie/frank_energie.py
@@ -52,6 +52,7 @@ from .models import (
     UserSites,
     UserSmartFeedInStatus,
 )
+from .types import PriceResolution
 
 T = TypeVar("T")
 
@@ -2220,7 +2221,7 @@ class FrankEnergie:
         country: str,
         start_date: date | None = None,
         end_date: date | None = None,
-        resolution: str | None = "PT15M",
+        resolution: PriceResolution = "PT15M",
     ) -> MarketPrices:
         """Get market prices for a country served via the 'x-country' header (e.g. BE, FR)."""
         if start_date is None:
@@ -2267,22 +2268,22 @@ class FrankEnergie:
         return MarketPrices.from_country_dict(response, country)
 
     async def be_prices(
-        self, start_date: date | None = None, end_date: date | None = None, resolution: str | None = "PT15M"
+        self, start_date: date | None = None, end_date: date | None = None, resolution: PriceResolution = "PT15M"
     ) -> MarketPrices:
         """Get belgium market prices."""
         return await self.country_prices("BE", start_date, end_date, resolution)
 
     async def fr_prices(
-        self, start_date: date | None = None, end_date: date | None = None, resolution: str | None = "PT15M"
+        self, start_date: date | None = None, end_date: date | None = None, resolution: PriceResolution = "PT15M"
     ) -> MarketPrices:
         """Get france market prices."""
         return await self.country_prices("FR", start_date, end_date, resolution)
 
     async def prices(
         self,
-        start_date: date | None | None = None,
-        end_date: date | None | None = None,
-        resolution: str | None | None = None,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        resolution: PriceResolution = "PT15M",
     ) -> MarketPrices:
         """Get market prices."""
         if not start_date:

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -2619,10 +2619,10 @@ class Price:
         """ The market price of the product or service. """
         self.market_price = data["marketPrice"]
         """ The amount of tax added to the market price. """
-        self.market_price_tax = data["marketPriceTax"]
+        self.market_price_tax = data.get("marketPriceTax") or 0.0
         """ The amount of sourcing markup added to the market price. """
-        self.sourcing_markup_price = data["sourcingMarkupPrice"]
-        self.energy_tax_price = data["energyTaxPrice"]
+        self.sourcing_markup_price = data.get("sourcingMarkupPrice") or 0.0
+        self.energy_tax_price = data.get("energyTaxPrice") or 0.0
         self.market_price_including_tax = self.market_price + self.market_price_tax
 
         # Tax added to the market price including tax and markup
@@ -3831,22 +3831,24 @@ class MarketPrices:
         return cls._parse_prices(market_prices, energy_country)
 
     @classmethod
-    def from_be_dict(cls, data: dict[str, object]) -> MarketPrices:
+    def from_country_dict(cls, data: dict[str, object], energy_country: str) -> MarketPrices:
         """
-        Create MarketPrices instance from BE market prices dict.
+        Create MarketPrices instance from a country-scoped market prices dict.
+
+        Used for countries served via the 'x-country' header (e.g. BE, FR).
 
         Args:
-            data: Dictionary with market prices data in BE format.
+            data: Dictionary with market prices data in the country-scoped format.
+            energy_country: The country code the data was fetched for (e.g. 'BE', 'FR').
 
         Returns:
             MarketPrices instance populated from the provided dict.
 
         # NOTE:
-        # This method only validates and extracts raw BE payload.
+        # This method only validates and extracts the raw country-scoped payload.
         # Normalization is handled in the coordinator layer.
         """
-        energy_country = "BE"
-        _LOGGER.debug("BE Market Prices keys: %s", list(data.keys()))
+        _LOGGER.debug("%s Market Prices keys: %s", energy_country, list(data.keys()))
 
         # Defensive: if empty data, return empty PriceData
         if not data:
@@ -3856,7 +3858,7 @@ class MarketPrices:
                 energy_country=energy_country,
             )
 
-        _LOGGER.debug("BE Market Prices data: %s", data)
+        _LOGGER.debug("%s Market Prices data: %s", energy_country, data)
 
         if data.get("errors"):
             error = cls._extract_error(data, "Unknown API error")
@@ -3868,18 +3870,23 @@ class MarketPrices:
 
         root = data.get("data")
         if not isinstance(root, dict):
-            raise RequestException("Missing 'data' in BE response")
+            raise RequestException(f"Missing 'data' in {energy_country} response")
 
-        _LOGGER.debug("BE Market Prices root: %s", root)
+        _LOGGER.debug("%s Market Prices root: %s", energy_country, root)
 
         market_prices = root.get("marketPrices")
         _LOGGER.debug("Type of payload data: %s", type(market_prices))
         if not isinstance(market_prices, dict):
-            raise RequestException("Missing 'marketPrices' in BE response")
+            raise RequestException(f"Missing 'marketPrices' in {energy_country} response")
 
-        _LOGGER.debug("BE Market Prices payload: %s", market_prices)
+        _LOGGER.debug("%s Market Prices payload: %s", energy_country, market_prices)
 
         return cls._parse_prices(market_prices, energy_country)
+
+    @classmethod
+    def from_be_dict(cls, data: dict[str, object]) -> MarketPrices:
+        """Create MarketPrices instance from BE market prices dict."""
+        return cls.from_country_dict(data, "BE")
 
     @classmethod
     def from_userprices_dict(cls, data: dict[str, object], energy_country: str) -> MarketPrices:

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -2619,10 +2619,13 @@ class Price:
         """ The market price of the product or service. """
         self.market_price = data["marketPrice"]
         """ The amount of tax added to the market price. """
-        self.market_price_tax = data.get("marketPriceTax") or 0.0
+        market_price_tax = data.get("marketPriceTax")
+        self.market_price_tax = market_price_tax if market_price_tax is not None else 0.0
         """ The amount of sourcing markup added to the market price. """
-        self.sourcing_markup_price = data.get("sourcingMarkupPrice") or 0.0
-        self.energy_tax_price = data.get("energyTaxPrice") or 0.0
+        sourcing_markup_price = data.get("sourcingMarkupPrice")
+        self.sourcing_markup_price = sourcing_markup_price if sourcing_markup_price is not None else 0.0
+        energy_tax_price = data.get("energyTaxPrice")
+        self.energy_tax_price = energy_tax_price if energy_tax_price is not None else 0.0
         self.market_price_including_tax = self.market_price + self.market_price_tax
 
         # Tax added to the market price including tax and markup

--- a/python_frank_energie/types.py
+++ b/python_frank_energie/types.py
@@ -1,4 +1,4 @@
 from typing import Literal
 
-CountryCode = Literal["NL", "BE"]
+CountryCode = Literal["NL", "BE", "FR"]
 PriceResolution = Literal["PT15M", "PT60M"]

--- a/tests/test_frank_energie.py
+++ b/tests/test_frank_energie.py
@@ -351,7 +351,7 @@ async def test_prices(aresponses):
 
     async with aiohttp.ClientSession() as session:
         api = FrankEnergie(session)
-        prices = await api.prices(datetime.now(UTC), datetime.now(UTC))
+        prices = await api.prices(datetime.now(UTC))
         await api.close()
 
     assert prices.electricity is not None

--- a/tests/test_frank_energie.py
+++ b/tests/test_frank_energie.py
@@ -1348,6 +1348,73 @@ async def test_be_prices_with_default_dates():
 
 
 @pytest.mark.asyncio
+async def test_fr_prices_with_default_dates():
+    """Test French prices method with default date handling."""
+    from datetime import datetime
+
+    client = FrankEnergie()
+
+    mock_response = {"data": {"marketPrices": {"electricityPrices": [], "gasPrices": []}}}
+
+    with patch.object(client, "_query", return_value=mock_response) as mock_query:
+        await client.fr_prices()
+        call_args = mock_query.call_args
+        query_obj = call_args[0][0]
+        variables = query_obj.variables
+
+        utc_today = datetime.now(UTC).date()
+
+        assert variables["date"] == str(utc_today)
+
+
+@pytest.mark.asyncio
+async def test_fr_prices_sets_x_country_header():
+    """Test French prices method sends the x-country: FR header."""
+    client = FrankEnergie()
+
+    mock_response = {"data": {"marketPrices": {"electricityPrices": [], "gasPrices": []}}}
+
+    with patch.object(client, "_query", return_value=mock_response) as mock_query:
+        await client.fr_prices()
+        call_args = mock_query.call_args
+
+        assert call_args.kwargs["extra_headers"] == {"x-country": "FR"}
+
+
+@pytest.mark.asyncio
+async def test_country_prices_defaults_to_15_minute_resolution():
+    """Test country_prices requests PT15M resolution by default.
+
+    Regression test: the 'x-country' market prices query previously omitted
+    the resolution argument entirely, silently always returning the backend's
+    default (hourly/PT60M) data regardless of the configured resolution.
+    """
+    client = FrankEnergie()
+
+    mock_response = {"data": {"marketPrices": {"electricityPrices": [], "gasPrices": []}}}
+
+    with patch.object(client, "_query", return_value=mock_response) as mock_query:
+        await client.country_prices("FR")
+        query_obj = mock_query.call_args[0][0]
+
+        assert query_obj.variables["resolution"] == "PT15M"
+
+
+@pytest.mark.asyncio
+async def test_country_prices_forwards_requested_resolution():
+    """Test country_prices forwards an explicitly requested resolution."""
+    client = FrankEnergie()
+
+    mock_response = {"data": {"marketPrices": {"electricityPrices": [], "gasPrices": []}}}
+
+    with patch.object(client, "_query", return_value=mock_response) as mock_query:
+        await client.country_prices("BE", resolution="PT60M")
+        query_obj = mock_query.call_args[0][0]
+
+        assert query_obj.variables["resolution"] == "PT60M"
+
+
+@pytest.mark.asyncio
 async def test_user_prices_date_validation():
     """Test user prices method date validation and formatting."""
     from datetime import date

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -406,6 +406,45 @@ def test_market_prices_no_market_prices_available_be():
     assert "No marketprices found" in str(excinfo.value)
 
 
+def test_market_prices_no_market_prices_available_fr():
+    """Test MarketPrices.from_country_dict raises NoMarketPricesAvailableException for FR 'No marketprices found' errors."""
+    with pytest.raises(NoMarketPricesAvailableException) as excinfo:
+        MarketPrices.from_country_dict(
+            {"errors": [{"message": "No marketprices found for segment ELECTRICITY for 2026-07-02"}]},
+            "FR",
+        )
+
+    assert "No marketprices found" in str(excinfo.value)
+
+
+def test_market_prices_from_country_dict_fr():
+    """Test MarketPrices.from_country_dict parses a FR market prices payload."""
+    market_prices = MarketPrices.from_country_dict(
+        {
+            "data": {
+                "marketPrices": {
+                    "electricityPrices": [
+                        {
+                            "from": "2026-07-22T00:00:00.000Z",
+                            "till": "2026-07-22T01:00:00.000Z",
+                            "marketPrice": 0.15,
+                            "marketPriceTax": 0.03,
+                            "sourcingMarkupPrice": 0.02,
+                            "energyTaxPrice": 0.01,
+                            "perUnit": "KWH",
+                        },
+                    ],
+                    "gasPrices": [],
+                }
+            }
+        },
+        "FR",
+    )
+
+    assert market_prices.energy_country == "FR"
+    assert len(market_prices.electricity.price_data) == 1
+
+
 @freeze_time("2022-11-21 14:15:00")
 def test_market_prices_pricedata_current_hour():
     """Test functionality of MarketPrices.price_data."""
@@ -515,6 +554,36 @@ def test_price_and_pricedata_per_unit():
         market_price=0.052,
     )
     assert avg_price_data.per_unit == "KWH"
+
+
+def test_price_handles_null_tax_and_markup_fields():
+    """Test Price tolerates marketPriceTax/sourcingMarkupPrice/energyTaxPrice being None.
+
+    Regression test: France's public marketPrices response only populates
+    marketPrice and perUnit, leaving the tax/markup breakdown fields as null.
+    Price.__init__ previously assumed these were always numeric and crashed
+    with `TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'`.
+    """
+    from python_frank_energie.models import Price
+
+    price_dict = {
+        "from": "2026-07-21T22:00:00.000Z",
+        "till": "2026-07-21T23:00:00.000Z",
+        "marketPrice": 0.15423,
+        "marketPriceTax": None,
+        "sourcingMarkupPrice": None,
+        "energyTaxPrice": None,
+        "perUnit": "KWH",
+    }
+
+    price = Price(price_dict, energy_type="electricity")
+
+    assert price.market_price == 0.15423
+    assert price.market_price_tax == 0.0
+    assert price.sourcing_markup_price == 0.0
+    assert price.energy_tax_price == 0.0
+    assert price.market_price_including_tax == 0.15423
+    assert price.market_price_including_tax_and_markup == 0.15423
 
 
 #

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -578,12 +578,12 @@ def test_price_handles_null_tax_and_markup_fields():
 
     price = Price(price_dict, energy_type="electricity")
 
-    assert price.market_price == 0.15423
-    assert price.market_price_tax == 0.0
-    assert price.sourcing_markup_price == 0.0
-    assert price.energy_tax_price == 0.0
-    assert price.market_price_including_tax == 0.15423
-    assert price.market_price_including_tax_and_markup == 0.15423
+    assert price.market_price == pytest.approx(0.15423)
+    assert price.market_price_tax == pytest.approx(0.0)
+    assert price.sourcing_markup_price == pytest.approx(0.0)
+    assert price.energy_tax_price == pytest.approx(0.0)
+    assert price.market_price_including_tax == pytest.approx(0.15423)
+    assert price.market_price_including_tax_and_markup == pytest.approx(0.15423)
 
 
 #


### PR DESCRIPTION
## Summary
- Add `FR` to `CountryCode` (alongside `NL`/`BE`); France is served through the same `x-country` header mechanism already used for Belgium.
- Generalize `be_prices()` into a shared `country_prices(country, ...)` helper (`be_prices()`/new `fr_prices()` are now thin wrappers), and `MarketPrices.from_be_dict()` into `from_country_dict(data, country)`.
- Fix `Price.__init__` crashing (`TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'`) when `marketPriceTax`/`sourcingMarkupPrice`/ `energyTaxPrice` are `null` — which France's public `marketPrices` response always does (BE always returns numeric values here). They now default to `0.0`.
- Fix the `x-country` `marketPrices` query never requesting a resolution — it silently always returned hourly data regardless of the configured resolution. This affected BE too, just never surfaced. `country_prices()`/`be_prices()`/ `fr_prices()` now accept and forward a `resolution` parameter (default `PT15M`).

## Test plan
- [x] `pytest tests/` — 264 passed
- [x] `ruff format` / `ruff check` — clean
- [x] Live-verified against Frank's public GraphQL API (`x-country: FR`) and against a running Home Assistant dev container using this library — price fetch succeeds and resolution is honored (96 × 15-min entries/day)

## Summary by Sourcery

Voeg Frankrijk (FR) toe als ondersteunde x-country markt en generaliseer het ophalen en parsen van land-gescope prijzen.

Nieuwe features:
- Introduceer FR als ondersteunde CountryCode naast NL en BE.
- Voeg `fr_prices` helper toe die marktprijzen voor Frankrijk ophaalt via de x-country header.
- Voeg gedeelde `country_prices` API toe voor het ophalen van marktprijzen voor markten die via x-country worden bediend.

Bugfixes:
- Standaardiseer belasting- en opslagvelden op 0,0 wanneer ze ontbreken of null zijn in `Price` om crashes op Franse payloads te voorkomen.
- Zorg ervoor dat land-gescope `marketPrices`-queries een `resolution`-parameter bevatten en respecteren in plaats van altijd uurlijkse data terug te geven.
- Verbeter foutafhandeling en meldingen bij het parsen van land-gescope `MarketPrices` voor ontbrekende data of `marketPrices`-velden.

Verbeteringen:
- Refactor de BE-specifieke `MarketPrices.from_be_dict` naar een generieke `from_country_dict` die wordt gebruikt door BE en FR.
- Maak het ophalen van Belgische prijzen uniform door de generieke `country_prices` helper te gebruiken, terwijl de bestaande `be_prices` API behouden blijft.

Tests:
- Voeg tests toe voor het parsen van FR-marktprijzen en foutafhandeling.
- Voeg regressietests toe die het gedrag van `Price` valideren bij null belasting-/opslagvelden.
- Voeg tests toe die garanderen dat `country_prices` en FR/BE helpers standaard naar en de gevraagde `resolution` doorgeven.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add France (FR) as a supported x-country market and generalize country-scoped price fetching and parsing.

New Features:
- Introduce FR as a supported CountryCode alongside NL and BE.
- Add fr_prices helper that fetches France market prices via the x-country header.
- Add shared country_prices API for fetching market prices for x-country-served markets.

Bug Fixes:
- Default tax and markup fields to 0.0 when missing or null in Price to avoid crashes on French payloads.
- Ensure country-scoped marketPrices queries include and respect a resolution parameter instead of always returning hourly data.
- Improve error handling and messaging in country-scoped MarketPrices parsing for missing data or marketPrices fields.

Enhancements:
- Refactor BE-specific MarketPrices.from_be_dict into a generic from_country_dict used by BE and FR.
- Unify Belgium price fetching to use the generic country_prices helper while preserving existing be_prices API.

Tests:
- Add tests for FR market prices parsing and error handling.
- Add regression tests validating Price behavior with null tax/markup fields.
- Add tests ensuring country_prices and FR/BE helpers default to and forward the requested resolution.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving French (FR) electricity market prices.
  - Added country-specific price retrieval with configurable date ranges and time resolution, including 15-minute and 60-minute intervals.
  - Belgium price retrieval now supports configurable resolution options.

- **Bug Fixes**
  - Improved handling of responses with missing tax or markup fields.
  - Added clearer validation for unavailable or malformed market-price data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->