### PR TITLE
fix: add STANDARD to SmartBatteryImbalanceStrategy enum

### DIFF
--- a/python_frank_energie/domain.py
+++ b/python_frank_energie/domain.py
@@ -133,6 +133,7 @@ class SmartBatteryImbalanceStrategy(StrEnum):
     CONSERVATIVE = "conservative"
     IMBALANCE_ONLY = "imbalance_only"
     AGGRESSIVE = "aggressive"
+    STANDARD = "standard"
     UNKNOWN = "unknown"
 
     @classmethod

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -21,6 +21,7 @@ from python_frank_energie.domain import (
         (SessionStatus, "PENDING", "PENDING"),
         (SmartBatteryMode, "IMBALANCE_TRADING", "imbalance_trading"),
         (SmartBatteryImbalanceStrategy, "BALANCED", "balanced"),
+        (SmartBatteryImbalanceStrategy, "STANDARD", "standard"),
         (SmartBatteryStatus, "STATUS_IDLE", "status_idle"),
         (SmartPvOperationalStatus, "ON", "ON"),
         (SmartPvSteeringStatus, "ACTIVE", "ACTIVE"),


### PR DESCRIPTION
## Summary
- The Frank Energie API started returning "STANDARD" as an imbalance trading strategy value, which the `SmartBatteryImbalanceStrategy` enum didn't have a member for, so it fell through to `UNKNOWN`.
- Adds `STANDARD = "standard"` to the enum and a case-insensitive parsing test case alongside the existing ones.

Fixes HiDiHo01/home-assistant-frank_energie#246

## Test plan
- [x] `pytest tests/test_domain.py` passes
- [x] Full test suite passes (265 passed)

## Summary by Sourcery

Ondersteuning toevoegen voor de STANDARD smart battery imbalance-strategiewaarde die wordt geretourneerd door de Frank Energie API.

Bugfixes:
- De STANDARD imbalance trading-strategie koppelen aan een dedicated `SmartBatteryImbalanceStrategy` enum-member in plaats van terug te vallen op `UNKNOWN`.

Tests:
- De enum-parsingtests uitbreiden zodat de nieuwe STANDARD imbalance-strategie case-insensitief wordt gedekt.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for the STANDARD smart battery imbalance strategy value returned by the Frank Energie API.

Bug Fixes:
- Map the STANDARD imbalance trading strategy to a dedicated SmartBatteryImbalanceStrategy enum member instead of falling back to UNKNOWN.

Tests:
- Extend enum parsing tests to cover the new STANDARD imbalance strategy in a case-insensitive manner.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `standard` smart battery imbalance strategy option.
  * Strategy values can be recognized consistently regardless of letter casing.

* **Tests**
  * Expanded coverage to verify parsing of the new strategy option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->