### PR TITLE
fix: backfill token expiry from JWT claims on construction

### DIFF
--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -271,6 +271,38 @@ class Authentication:
     refresh_token_expires_at: datetime | None = None
     TOKEN_RENEWAL_MARGIN = timedelta(minutes=5)
 
+    def __post_init__(self) -> None:
+        """Backfill expiry from JWT claims when not explicitly provided.
+
+        Authentication is also constructed directly from persisted
+        access/refresh tokens (FrankEnergie.__init__), not only from a
+        login/renewToken response, and that path has no expiry to pass in.
+        """
+        if self.token_expires_at is None and self.authToken:
+            self.token_expires_at = self._decode_jwt_expiry(self.authToken)
+        if self.refresh_token_expires_at is None and self.refreshToken:
+            self.refresh_token_expires_at = self._decode_jwt_expiry(self.refreshToken)
+
+    @staticmethod
+    def _decode_jwt_expiry(token: str) -> datetime | None:
+        """Decode a JWT's 'exp' claim without verifying its signature.
+
+        Returns None on any decode failure or missing claim instead of
+        raising; callers treat an unknown expiry as "assume expired".
+        """
+        try:
+            decoded: dict[str, object] = jwt.decode(
+                token,
+                options={"verify_signature": False},
+                algorithms=["HS256"],
+            )
+        except InvalidTokenError:
+            return None
+        exp = decoded.get("exp")
+        if not isinstance(exp, (int, float)):
+            return None
+        return datetime.fromtimestamp(exp, tz=UTC)
+
     @staticmethod
     def from_dict(data: dict[str, object]) -> Authentication:
         """Parse the response from the login or renewToken mutation."""

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -284,27 +284,41 @@ class Authentication:
             self.refresh_token_expires_at = self._decode_jwt_expiry(self.refreshToken)
 
     @staticmethod
-    def _decode_jwt_expiry(token: str) -> datetime | None:
-        """Decode a JWT's 'exp' claim without verifying its signature.
+    def _decode_jwt_claims(token: str) -> dict[str, object] | None:
+        """Decode a JWT's claims without verifying its signature.
 
-        Returns None on any decode failure or missing claim instead of
-        raising; callers treat an unknown expiry as "assume expired".
+        Returns None if the token cannot be decoded at all.
         """
         try:
-            decoded: dict[str, object] = jwt.decode(
+            return jwt.decode(
                 token,
                 options={"verify_signature": False},
                 algorithms=["HS256"],
             )
         except InvalidTokenError:
             return None
-        exp = decoded.get("exp")
-        if not isinstance(exp, (int, float)) or not math.isfinite(exp):
+
+    @staticmethod
+    def _exp_to_datetime(exp: object) -> datetime | None:
+        """Convert a decoded 'exp' claim to a UTC datetime, or None if invalid."""
+        if isinstance(exp, bool) or not isinstance(exp, (int, float)) or not math.isfinite(exp):
             return None
         try:
             return datetime.fromtimestamp(exp, tz=UTC)
         except (OverflowError, OSError, ValueError):
             return None
+
+    @staticmethod
+    def _decode_jwt_expiry(token: str) -> datetime | None:
+        """Decode a JWT's 'exp' claim without verifying its signature.
+
+        Returns None on any decode failure or missing claim instead of
+        raising; callers treat an unknown expiry as "assume expired".
+        """
+        claims = Authentication._decode_jwt_claims(token)
+        if claims is None:
+            return None
+        return Authentication._exp_to_datetime(claims.get("exp"))
 
     @staticmethod
     def from_dict(data: dict[str, object]) -> Authentication:
@@ -342,47 +356,33 @@ class Authentication:
 
         # --- Expiry extraction ---
         token_expires_at: datetime | None = None
-        try:
-            decoded: dict[str, object] = jwt.decode(
-                auth_token,
-                options={"verify_signature": False},
-                algorithms=["HS256"],
-            )
-
+        decoded = Authentication._decode_jwt_claims(auth_token)
+        if decoded is not None:
             _LOGGER.debug("authToken decoded claims keys: %s", list(decoded.keys()))
 
-            exp = decoded.get("exp")
-            if not isinstance(exp, (int, float)):
+            token_expires_at = Authentication._exp_to_datetime(decoded.get("exp"))
+            if token_expires_at is None:
                 _LOGGER.warning("authToken missing 'exp' claim; treating as expired")
                 raise AuthException("Missing or invalid 'exp' in JWT")
 
-            token_expires_at = datetime.fromtimestamp(exp, tz=UTC)
             _LOGGER.debug("authToken expires at: %s", token_expires_at)
-
-        except InvalidTokenError as err:
-            _LOGGER.warning("Unable to decode authToken to extract expiration: %s", err)
+        else:
+            _LOGGER.warning("Unable to decode authToken to extract expiration")
 
         # --- Expiry extraction ---
         refresh_token_expires_at: datetime | None = None
-        try:
-            decoded: dict[str, object] = jwt.decode(
-                refresh_token,
-                options={"verify_signature": False},
-                algorithms=["HS256"],
-            )
-
+        decoded = Authentication._decode_jwt_claims(refresh_token)
+        if decoded is not None:
             _LOGGER.debug("refreshToken decoded claims keys: %s", list(decoded.keys()))
 
-            exp = decoded.get("exp")
-            if not isinstance(exp, (int, float)):
+            refresh_token_expires_at = Authentication._exp_to_datetime(decoded.get("exp"))
+            if refresh_token_expires_at is None:
                 _LOGGER.warning("refreshToken missing 'exp' claim; treating as expired")
                 raise AuthException("Missing or invalid 'exp' in JWT")
 
-            refresh_token_expires_at = datetime.fromtimestamp(exp, tz=UTC)
             _LOGGER.debug("authToken expires at: %s", refresh_token_expires_at)
-
-        except InvalidTokenError as err:
-            _LOGGER.warning("Unable to decode refreshToken to extract expiration: %s", err)
+        else:
+            _LOGGER.warning("Unable to decode refreshToken to extract expiration")
 
         return Authentication(
             authToken=auth_token,

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -299,9 +299,12 @@ class Authentication:
         except InvalidTokenError:
             return None
         exp = decoded.get("exp")
-        if not isinstance(exp, (int, float)):
+        if not isinstance(exp, (int, float)) or not math.isfinite(exp):
             return None
-        return datetime.fromtimestamp(exp, tz=UTC)
+        try:
+            return datetime.fromtimestamp(exp, tz=UTC)
+        except (OverflowError, OSError, ValueError):
+            return None
 
     @staticmethod
     def from_dict(data: dict[str, object]) -> Authentication:

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -321,6 +321,29 @@ class Authentication:
         return Authentication._exp_to_datetime(claims.get("exp"))
 
     @staticmethod
+    def _decode_expiry_or_raise(token: str, label: str) -> datetime | None:
+        """Decode a fresh login/renewToken token's expiry, or raise if unusable.
+
+        Returns None if the token can't be decoded at all (tolerated, as
+        for a mock/test token); raises AuthException if it decodes but
+        has no usable exp claim.
+        """
+        decoded = Authentication._decode_jwt_claims(token)
+        if decoded is None:
+            _LOGGER.warning("Unable to decode %s to extract expiration", label)
+            return None
+
+        _LOGGER.debug("%s decoded claims keys: %s", label, list(decoded.keys()))
+
+        expires_at = Authentication._exp_to_datetime(decoded.get("exp"))
+        if expires_at is None:
+            _LOGGER.warning("%s missing 'exp' claim; treating as expired", label)
+            raise AuthException("Missing or invalid 'exp' in JWT")
+
+        _LOGGER.debug("%s expires at: %s", label, expires_at)
+        return expires_at
+
+    @staticmethod
     def from_dict(data: dict[str, object]) -> Authentication:
         """Parse the response from the login or renewToken mutation."""
         _LOGGER.debug("Authentication response keys: %s", list(data.keys()))
@@ -355,34 +378,8 @@ class Authentication:
             raise AuthException("Invalid refreshToken")
 
         # --- Expiry extraction ---
-        token_expires_at: datetime | None = None
-        decoded = Authentication._decode_jwt_claims(auth_token)
-        if decoded is not None:
-            _LOGGER.debug("authToken decoded claims keys: %s", list(decoded.keys()))
-
-            token_expires_at = Authentication._exp_to_datetime(decoded.get("exp"))
-            if token_expires_at is None:
-                _LOGGER.warning("authToken missing 'exp' claim; treating as expired")
-                raise AuthException("Missing or invalid 'exp' in JWT")
-
-            _LOGGER.debug("authToken expires at: %s", token_expires_at)
-        else:
-            _LOGGER.warning("Unable to decode authToken to extract expiration")
-
-        # --- Expiry extraction ---
-        refresh_token_expires_at: datetime | None = None
-        decoded = Authentication._decode_jwt_claims(refresh_token)
-        if decoded is not None:
-            _LOGGER.debug("refreshToken decoded claims keys: %s", list(decoded.keys()))
-
-            refresh_token_expires_at = Authentication._exp_to_datetime(decoded.get("exp"))
-            if refresh_token_expires_at is None:
-                _LOGGER.warning("refreshToken missing 'exp' claim; treating as expired")
-                raise AuthException("Missing or invalid 'exp' in JWT")
-
-            _LOGGER.debug("authToken expires at: %s", refresh_token_expires_at)
-        else:
-            _LOGGER.warning("Unable to decode refreshToken to extract expiration")
+        token_expires_at = Authentication._decode_expiry_or_raise(auth_token, "authToken")
+        refresh_token_expires_at = Authentication._decode_expiry_or_raise(refresh_token, "refreshToken")
 
         return Authentication(
             authToken=auth_token,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,9 @@
 """Tests for Frank Energie Models."""
 
 import json
+from datetime import UTC, datetime, timedelta
 
+import jwt
 import pytest
 from freezegun import freeze_time
 from syrupy.assertion import SnapshotAssertion
@@ -59,6 +61,67 @@ def test_authentication_error_message():
         Authentication.from_dict({"errors": [{"message": "help me"}]})
 
     assert "help me" in str(excinfo.value)
+
+
+def _make_jwt(exp: object) -> str:
+    if exp is None:
+        return jwt.encode({}, "test-secret-that-is-long-enough-for-hs256", algorithm="HS256")
+    return jwt.encode({"exp": exp}, "test-secret-that-is-long-enough-for-hs256", algorithm="HS256")
+
+
+def test_authentication_post_init_backfills_expiry_from_persisted_tokens():
+    """Authentication built from persisted tokens (no expiry given) decodes exp itself."""
+    future = datetime.now(UTC) + timedelta(hours=1)
+    token = _make_jwt(int(future.timestamp()))
+
+    auth = Authentication(authToken=token, refreshToken=token, version=None)
+
+    assert auth.token_expires_at is not None
+    assert auth.refresh_token_expires_at is not None
+    assert auth.is_expired is False
+
+
+def test_authentication_post_init_expired_token_reports_expired():
+    """A persisted token whose exp has already passed is reported as expired."""
+    past = datetime.now(UTC) - timedelta(minutes=10)
+    token = _make_jwt(int(past.timestamp()))
+
+    auth = Authentication(authToken=token, refreshToken=token, version=None)
+
+    assert auth.is_expired is True
+
+
+@pytest.mark.parametrize(
+    "exp",
+    [None, float("inf"), float("-inf"), float("nan"), 10**20, -(10**20), True],
+)
+def test_decode_jwt_expiry_returns_none_for_invalid_exp(exp):
+    """Missing, non-finite, out-of-range, or boolean exp claims yield None, not a raised exception."""
+    token = _make_jwt(exp)
+
+    assert Authentication._decode_jwt_expiry(token) is None
+
+
+def test_decode_jwt_expiry_returns_none_for_undecodable_token():
+    """A token that isn't a JWT at all yields None rather than raising."""
+    assert Authentication._decode_jwt_expiry("not-a-jwt") is None
+
+
+def test_from_dict_raises_on_missing_exp_claim():
+    """A decodable JWT with no exp claim fails the login/renew parse, not a silent fallback."""
+    token = _make_jwt(None)
+    response = {"data": {"login": {"authToken": token, "refreshToken": "world"}}}
+
+    with pytest.raises(AuthException, match="Missing or invalid 'exp'"):
+        Authentication.from_dict(response)
+
+
+def test_from_dict_tolerates_undecodable_token():
+    """A non-JWT token (e.g. a test/mock token) is tolerated, not raised on."""
+    auth = Authentication.from_dict(json.loads(load_fixtures("authentication.json")))
+
+    assert auth.token_expires_at is None
+    assert auth.refresh_token_expires_at is None
 
 
 #


### PR DESCRIPTION
## Summary
- `Authentication.is_expired` treats an unknown `token_expires_at` as "expired" for any real-looking JWT. `FrankEnergie.__init__` builds `Authentication` straight from persisted access/refresh tokens (e.g. after a Home Assistant restart) without ever setting `token_expires_at`, so this path forced a `renew_token()` round trip on every single startup — even when the persisted token still had hours of validity left.
- `Authentication.__post_init__` now decodes the JWT `exp` claim (same decode already used in `from_dict`) to backfill `token_expires_at` / `refresh_token_expires_at` whenever they aren't explicitly provided, so `is_expired` reflects the token's real expiry from the moment it's constructed.

## Test plan
- [x] `pytest tests/` — 265 passed
- [x] `black --check` on the changed diff (repo has pre-existing unrelated formatting drift elsewhere in `models.py`, untouched by this change)
- [x] Manual check: a freshly-constructed `Authentication` with a not-yet-expired JWT now reports `is_expired == False`; an actually expired or non-JWT token keeps its prior behavior
- [x] Verified in a running Docker instance that startup no longer logs `Access token expired; attempting token renewal` / a `RenewToken` GraphQL call when the persisted token is still valid

## Summary by Sourcery

Vul de vervaltijdstempels van authenticatietokens achteraf in op basis van JWT-claims bij het construeren van Authentication-instances, zodat opgeslagen tokens bij het opstarten niet langer onnodige vernieuwingen triggeren.

Bugfixes:
- Zorg ervoor dat Authentication-instances die zijn aangemaakt op basis van opgeslagen access/refresh-tokens de JWT-vervaldatum correct weergeven in plaats van direct als verlopen te worden behandeld.

Verbeteringen:
- Voeg logica na initialisatie toe en een helper om JWT-vervalclaims te decoderen en de `token_expires_at`-velden in te vullen wanneer deze niet expliciet zijn opgegeven.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Backfill authentication token expiry timestamps from JWT claims when constructing Authentication instances so persisted tokens no longer trigger unnecessary renewals on startup.

Bug Fixes:
- Ensure Authentication instances created from persisted access/refresh tokens correctly reflect JWT expiry instead of being treated as immediately expired.

Enhancements:
- Add post-initialization logic and a helper to decode JWT expiry claims and populate token_expires_at fields when not explicitly provided.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication expiry times are now automatically restored from persisted tokens when available.
  * Invalid or incomplete token expiry data is handled gracefully without causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->