### PR TITLE
tests: add coverage for Price.for_current_quarter_hour

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -884,6 +884,37 @@ def test_price_data_add_validates_metadata() -> None:
         _ = left + right_diff_type
 
 
+def test_price_for_current_quarter_hour_matches_current_interval() -> None:
+    """Price.for_current_quarter_hour is true for the active 15-minute price."""
+    from python_frank_energie.models import Price
+
+    active_price = Price(
+        {
+            "from": "2026-07-19T22:15:00.000Z",
+            "till": "2026-07-19T22:30:00.000Z",
+            "marketPrice": 0.1,
+            "marketPriceTax": 0.02,
+            "sourcingMarkupPrice": 0.01,
+            "energyTaxPrice": 0.1,
+        }
+    )
+    upcoming_price = Price(
+        {
+            "from": "2026-07-19T22:30:00.000Z",
+            "till": "2026-07-19T22:45:00.000Z",
+            "marketPrice": 0.1,
+            "marketPriceTax": 0.02,
+            "sourcingMarkupPrice": 0.01,
+            "energyTaxPrice": 0.1,
+        }
+    )
+
+    with freeze_time("2026-07-19T22:20:00Z"):
+        assert active_price.for_current_quarter_hour is True
+        assert active_price.for_current_quarter_hour == active_price.for_now
+        assert upcoming_price.for_current_quarter_hour is False
+
+
 def test_price_data_derives_resolution_minutes_from_entry_spacing() -> None:
     """PriceData must derive resolution_minutes from the actual entry spacing.
 


### PR DESCRIPTION
### Motivation
- Add a regression test to ensure `Price.for_current_quarter_hour` correctly reports the active 15-minute interval and remains equivalent to `for_now`.

### Description
- Add `test_price_for_current_quarter_hour_matches_current_interval` to `tests/test_models.py`, constructing active and upcoming `Price` instances and asserting behavior under `freeze_time`.

### Testing
- Ran `pytest -q tests/test_models.py -k 'current_quarter_hour or resolution_minutes'`, which passed (`3 passed, 64 deselected`).
- Ran `pytest -q` (full test run), which failed during collection with `ModuleNotFoundError: No module named 'dotenv'` for several `scripts/test_*.py` tests due to a missing `python-dotenv` dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e55976ca4832292247e86fa2760ff)

## Summary by Sourcery

Tests:
- Voeg een regressietest toe die ervoor zorgt dat `Price.for_current_quarter_hour` overeenkomt met het huidige interval en equivalent blijft aan `for_now`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Add a regression test ensuring Price.for_current_quarter_hour matches the current interval and remains equivalent to for_now.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage to verify that prices are marked current only during the active 15-minute interval and align with the current-time status.
  * Confirmed that upcoming prices are not incorrectly identified as current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->