### PR TITLE
Add previous/next quarter-hour helpers and tests for PT15M intervals

### DIFF
--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -2729,6 +2729,17 @@ class Price:
         return f"{date_from_str} -> {date_till_str}: {self.total:.4f} {self.per_unit or ''}"
 
     @property
+    def for_previous_quarter_hour(self) -> bool:
+        """True when this interval covered the UTC time from 15 minutes ago.
+
+        Mirrors ``for_current_quarter_hour`` by checking whether a point in
+        time falls within this price interval instead of reconstructing the
+        interval boundary.
+        """
+        previous_quarter_hour = datetime.now(UTC) - timedelta(minutes=15)
+        return self.date_from <= previous_quarter_hour < self.date_till
+
+    @property
     def for_current_quarter_hour(self) -> bool:
         """True when the current UTC time falls within this 15-minute interval.
 
@@ -2739,6 +2750,17 @@ class Price:
         """
         now = datetime.now(UTC)
         return self.date_from <= now < self.date_till
+
+    @property
+    def for_next_quarter_hour(self) -> bool:
+        """True when this interval covers the UTC time 15 minutes from now.
+
+        Mirrors ``for_current_quarter_hour`` by checking whether a point in
+        time falls within this price interval instead of reconstructing the
+        interval boundary.
+        """
+        next_quarter_hour = datetime.now(UTC) + timedelta(minutes=15)
+        return self.date_from <= next_quarter_hour < self.date_till
 
     @property
     def for_now(self) -> bool:
@@ -3129,6 +3151,11 @@ class PriceData:
         return None
 
     @property
+    def previous_quarter_hour(self) -> Price | None:
+        """Return the price entry for the previous 15-minute interval."""
+        return next((p for p in self.price_data if p.for_previous_quarter_hour), None)
+
+    @property
     def current_quarter_hour(self) -> Price | None:
         """Return the price entry that covers the current 15-minute interval.
 
@@ -3140,11 +3167,12 @@ class PriceData:
         Returns:
             The matching ``Price`` object, or ``None`` if not found.
         """
-        now = datetime.now(UTC)
-        return next(
-            (p for p in self.price_data if p.date_from <= now < p.date_till),
-            None,
-        )
+        return next((p for p in self.price_data if p.for_current_quarter_hour), None)
+
+    @property
+    def next_quarter_hour(self) -> Price | None:
+        """Return the price entry for the next 15-minute interval."""
+        return next((p for p in self.price_data if p.for_next_quarter_hour), None)
 
     @property
     def prices_for_current_hour(self) -> list[Price]:

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -2728,16 +2728,14 @@ class Price:
         date_till_str = self.date_till.isoformat() if self.date_till else "N/A"
         return f"{date_from_str} -> {date_till_str}: {self.total:.4f} {self.per_unit or ''}"
 
+    def contains_time(self, moment: datetime) -> bool:
+        """Return True when ``moment`` falls within this price interval."""
+        return self.date_from <= moment.astimezone(UTC) < self.date_till
+
     @property
     def for_previous_quarter_hour(self) -> bool:
-        """True when this interval covered the UTC time from 15 minutes ago.
-
-        Mirrors ``for_current_quarter_hour`` by checking whether a point in
-        time falls within this price interval instead of reconstructing the
-        interval boundary.
-        """
-        previous_quarter_hour = datetime.now(UTC) - timedelta(minutes=15)
-        return self.date_from <= previous_quarter_hour < self.date_till
+        """True when this interval covered the UTC time from 15 minutes ago."""
+        return self.contains_time(datetime.now(UTC) - timedelta(minutes=15))
 
     @property
     def for_current_quarter_hour(self) -> bool:
@@ -2748,19 +2746,12 @@ class Price:
         Identical logic to ``for_now``; exists as a named alias so sensor code
         can express intent clearly when working with PT15M data.
         """
-        now = datetime.now(UTC)
-        return self.date_from <= now < self.date_till
+        return self.contains_time(datetime.now(UTC))
 
     @property
     def for_next_quarter_hour(self) -> bool:
-        """True when this interval covers the UTC time 15 minutes from now.
-
-        Mirrors ``for_current_quarter_hour`` by checking whether a point in
-        time falls within this price interval instead of reconstructing the
-        interval boundary.
-        """
-        next_quarter_hour = datetime.now(UTC) + timedelta(minutes=15)
-        return self.date_from <= next_quarter_hour < self.date_till
+        """True when this interval covers the UTC time 15 minutes from now."""
+        return self.contains_time(datetime.now(UTC) + timedelta(minutes=15))
 
     @property
     def for_now(self) -> bool:
@@ -3153,7 +3144,8 @@ class PriceData:
     @property
     def previous_quarter_hour(self) -> Price | None:
         """Return the price entry for the previous 15-minute interval."""
-        return next((p for p in self.price_data if p.for_previous_quarter_hour), None)
+        previous_quarter_hour = datetime.now(UTC) - timedelta(minutes=15)
+        return next((p for p in self.price_data if p.contains_time(previous_quarter_hour)), None)
 
     @property
     def current_quarter_hour(self) -> Price | None:
@@ -3167,12 +3159,14 @@ class PriceData:
         Returns:
             The matching ``Price`` object, or ``None`` if not found.
         """
-        return next((p for p in self.price_data if p.for_current_quarter_hour), None)
+        now = datetime.now(UTC)
+        return next((p for p in self.price_data if p.contains_time(now)), None)
 
     @property
     def next_quarter_hour(self) -> Price | None:
         """Return the price entry for the next 15-minute interval."""
-        return next((p for p in self.price_data if p.for_next_quarter_hour), None)
+        next_quarter_hour = datetime.now(UTC) + timedelta(minutes=15)
+        return next((p for p in self.price_data if p.contains_time(next_quarter_hour)), None)
 
     @property
     def prices_for_current_hour(self) -> list[Price]:

--- a/python_frank_energie/models.py
+++ b/python_frank_energie/models.py
@@ -2729,8 +2729,8 @@ class Price:
         return f"{date_from_str} -> {date_till_str}: {self.total:.4f} {self.per_unit or ''}"
 
     def contains_time(self, moment: datetime) -> bool:
-        """Return True when ``moment`` falls within this price interval."""
-        return self.date_from <= moment.astimezone(UTC) < self.date_till
+        """Return True when the UTC ``moment`` falls within this price interval."""
+        return self.date_from <= moment < self.date_till
 
     @property
     def for_previous_quarter_hour(self) -> bool:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1055,3 +1055,49 @@ def test_quarter_hour_helpers(monkeypatch) -> None:
     assert price_data.previous_quarter_hour is previous
     assert price_data.current_quarter_hour is current
     assert price_data.next_quarter_hour is next_
+
+
+def test_current_quarter_hour_uses_single_now_evaluation(monkeypatch) -> None:
+    """PriceData.current_quarter_hour must not re-evaluate now per interval."""
+    from datetime import UTC, datetime
+
+    import python_frank_energie.models as models
+    from python_frank_energie.models import PriceData
+
+    class MovingDatetime(datetime):
+        calls = 0
+
+        @classmethod
+        def now(cls, tz=None):
+            cls.calls += 1
+            if cls.calls == 1:
+                fixed = cls(2026, 7, 19, 22, 17, 42, tzinfo=UTC)
+            else:
+                fixed = cls(2026, 7, 19, 22, 45, 0, tzinfo=UTC)
+            return fixed if tz is None else fixed.astimezone(tz)
+
+    monkeypatch.setattr(models, "datetime", MovingDatetime)
+
+    price_data = PriceData(
+        [
+            {
+                "from": "2026-07-19T22:00:00.000Z",
+                "till": "2026-07-19T22:15:00.000Z",
+                "marketPrice": 0.1,
+            },
+            {
+                "from": "2026-07-19T22:15:00.000Z",
+                "till": "2026-07-19T22:30:00.000Z",
+                "marketPrice": 0.2,
+            },
+            {
+                "from": "2026-07-19T22:30:00.000Z",
+                "till": "2026-07-19T22:45:00.000Z",
+                "marketPrice": 0.3,
+            },
+        ],
+        energy_type="electricity",
+    )
+
+    assert price_data.current_quarter_hour is price_data.price_data[1]
+    assert MovingDatetime.calls == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1009,3 +1009,49 @@ def test_market_prices_from_dict_derives_resolution_minutes() -> None:
     market_prices = MarketPrices.from_dict(response)
 
     assert market_prices.electricity.resolution_minutes == 15
+
+
+def test_quarter_hour_helpers(monkeypatch) -> None:
+    """Price and PriceData expose previous/current/next quarter-hour helpers."""
+    from datetime import UTC, datetime
+
+    import python_frank_energie.models as models
+    from python_frank_energie.models import PriceData
+
+    class FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            fixed = cls(2026, 7, 19, 22, 17, 42, tzinfo=UTC)
+            return fixed if tz is None else fixed.astimezone(tz)
+
+    monkeypatch.setattr(models, "datetime", FixedDatetime)
+
+    price_data = PriceData(
+        [
+            {
+                "from": "2026-07-19T22:00:00.000Z",
+                "till": "2026-07-19T22:15:00.000Z",
+                "marketPrice": 0.1,
+            },
+            {
+                "from": "2026-07-19T22:15:00.000Z",
+                "till": "2026-07-19T22:30:00.000Z",
+                "marketPrice": 0.2,
+            },
+            {
+                "from": "2026-07-19T22:30:00.000Z",
+                "till": "2026-07-19T22:45:00.000Z",
+                "marketPrice": 0.3,
+            },
+        ],
+        energy_type="electricity",
+    )
+
+    previous, current, next_ = price_data.price_data
+
+    assert previous.for_previous_quarter_hour
+    assert current.for_current_quarter_hour
+    assert next_.for_next_quarter_hour
+    assert price_data.previous_quarter_hour is previous
+    assert price_data.current_quarter_hour is current
+    assert price_data.next_quarter_hour is next_


### PR DESCRIPTION
### Motivation

- Provide explicit helpers to identify the previous and next 15-minute (PT15M) price intervals to make sensor code clearer and avoid reconstructing interval boundaries. 
- Make quarter-hour checks symmetric with the existing `for_current_quarter_hour` logic so callers can easily ask for previous/current/next intervals.

### Description

- Add `Price.for_previous_quarter_hour` and `Price.for_next_quarter_hour` properties that check whether a point in time 15 minutes before or after now falls within the interval.  
- Add `PriceData.previous_quarter_hour` and `PriceData.next_quarter_hour` properties that return the matching `Price` for the previous and next 15-minute intervals.  
- Simplify `PriceData.current_quarter_hour` to use the `Price.for_current_quarter_hour` predicate instead of repeating the time comparison.  
- Add unit test `test_quarter_hour_helpers` in `tests/test_models.py` that monkeypatches `datetime.now` to a fixed UTC instant and asserts the previous/current/next helpers return the expected `Price` objects.

### Testing

- Ran the new unit test `tests/test_models.py::test_quarter_hour_helpers` using `pytest` and it passed.  
- Ran the package test suite with `pytest` and all tests, including the newly added quarter-hour test, succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e57684708832292e8c604081d0b59)

## Samenvatting door Sourcery

Voeg helper-eigenschappen toe voor het navigeren tussen vorige, huidige en volgende 15‑minuten prijsintervallen en valideer deze met een dedicated unittest.

Nieuwe features:
- Stel de predicates `Price.for_previous_quarter_hour` en `Price.for_next_quarter_hour` beschikbaar om prijzen voor aangrenzende 15‑minutenintervallen te identificeren.
- Stel de eigenschappen `PriceData.previous_quarter_hour` en `PriceData.next_quarter_hour` beschikbaar om prijzen op te halen voor de vorige en volgende 15‑minutenintervallen.

Verbeteringen:
- Vereenvoudig `PriceData.current_quarter_hour` door de predicate `Price.for_current_quarter_hour` te hergebruiken in plaats van de tijdvergelijkingslogica te dupliceren.

Tests:
- Voeg `test_quarter_hour_helpers` toe om het gedrag van de vorige/huidige/volgende quarter‑hour helpers van `Price` en `PriceData` te verifiëren tegen vaste UTC‑tijdstempels.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add helper properties for navigating previous, current, and next 15‑minute price intervals and validate them with a dedicated unit test.

New Features:
- Expose Price.for_previous_quarter_hour and Price.for_next_quarter_hour predicates to identify prices for adjacent 15‑minute intervals.
- Expose PriceData.previous_quarter_hour and PriceData.next_quarter_hour properties to fetch prices for the previous and next 15‑minute intervals.

Enhancements:
- Simplify PriceData.current_quarter_hour to reuse the Price.for_current_quarter_hour predicate instead of duplicating time comparison logic.

Tests:
- Add test_quarter_hour_helpers to verify Price and PriceData previous/current/next quarter‑hour helper behavior against fixed UTC timestamps.

</details>